### PR TITLE
fix: Corriger le blocage de l'équerre lors de la réactivation

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,7 +13,11 @@ def create_app(config_name='development'):
         app.config.from_object(ProductionConfig)
     else:
         app.config.from_object(Config)
-    
+
+    # Forcer le rechargement des templates en production pour éviter le cache
+    app.config['TEMPLATES_AUTO_RELOAD'] = True
+    app.jinja_env.auto_reload = True
+
     # Initialisation des extensions
     db.init_app(app)
     migrate.init_app(app, db)

--- a/migrations/versions/20260124_add_lesson_blank_sheets.py
+++ b/migrations/versions/20260124_add_lesson_blank_sheets.py
@@ -1,0 +1,63 @@
+"""Add lesson_blank_sheets table
+
+Revision ID: 20260124_add_blank_sheets
+Revises: allow_other_periods_001
+Create Date: 2026-01-24
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '20260124_add_blank_sheets'
+down_revision = 'allow_other_periods_001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Créer la table lesson_blank_sheets
+    op.create_table(
+        'lesson_blank_sheets',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.id'), nullable=False),
+        sa.Column('classroom_id', sa.Integer(), sa.ForeignKey('classrooms.id'), nullable=True),
+        sa.Column('lesson_date', sa.Date(), nullable=False),
+        sa.Column('period_number', sa.Integer(), nullable=False),
+        sa.Column('title', sa.String(200), default='Feuille blanche'),
+        sa.Column('sheet_data', postgresql.JSON(astext_type=sa.Text()), nullable=False),
+        sa.Column('created_at', sa.DateTime(), default=sa.func.now()),
+        sa.Column('updated_at', sa.DateTime(), default=sa.func.now(), onupdate=sa.func.now())
+    )
+
+    # Créer un index composite pour les requêtes fréquentes (user + date + période)
+    op.create_index(
+        'idx_blank_sheets_user_date_period',
+        'lesson_blank_sheets',
+        ['user_id', 'lesson_date', 'period_number']
+    )
+
+    # Index sur lesson_date pour les requêtes par date
+    op.create_index(
+        'idx_blank_sheets_lesson_date',
+        'lesson_blank_sheets',
+        ['lesson_date']
+    )
+
+    # Index sur period_number pour les requêtes par période
+    op.create_index(
+        'idx_blank_sheets_period_number',
+        'lesson_blank_sheets',
+        ['period_number']
+    )
+
+
+def downgrade():
+    # Supprimer les index
+    op.drop_index('idx_blank_sheets_period_number', table_name='lesson_blank_sheets')
+    op.drop_index('idx_blank_sheets_lesson_date', table_name='lesson_blank_sheets')
+    op.drop_index('idx_blank_sheets_user_date_period', table_name='lesson_blank_sheets')
+
+    # Supprimer la table
+    op.drop_table('lesson_blank_sheets')

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -22,6 +22,7 @@ from models.mixed_group import MixedGroup, MixedGroupStudent
 from models.user_preferences import UserPreferences, UserSanctionPreferences
 from models.accommodation import AccommodationTemplate, StudentAccommodation
 from models.lesson_memo import LessonMemo, StudentRemark
+from models.lesson_blank_sheet import LessonBlankSheet
 
 __all__ = ['User', 'Holiday', 'Break', 'Classroom', 'Schedule', 'Planning',
            'Student', 'Grade', 'LegacyClassFile', 'ClassFile', 'Chapter', 'ClassroomChapter', 'StudentFile', 'StudentInfoHistory', 'Attendance', 'FileFolder', 'UserFile', 'FileShare',
@@ -29,4 +30,4 @@ __all__ = ['User', 'Holiday', 'Break', 'Classroom', 'Schedule', 'Planning',
            'Evaluation', 'EvaluationGrade', 'SeatingPlan', 'StudentGroup', 'StudentGroupMembership',
            'ClassMaster', 'TeacherAccessCode', 'TeacherCollaboration', 'SharedClassroom', 'StudentClassroomLink', 'TeacherInvitation', 'InvitationClassroom',
            'ClassroomAccessCode', 'StudentFileShare', 'MixedGroup', 'MixedGroupStudent', 'UserPreferences', 'UserSanctionPreferences',
-           'AccommodationTemplate', 'StudentAccommodation', 'LessonMemo', 'StudentRemark']
+           'AccommodationTemplate', 'StudentAccommodation', 'LessonMemo', 'StudentRemark', 'LessonBlankSheet']

--- a/models/lesson_blank_sheet.py
+++ b/models/lesson_blank_sheet.py
@@ -1,0 +1,50 @@
+"""
+Modèle pour les feuilles blanches associées aux leçons
+"""
+from datetime import datetime
+from extensions import db
+
+
+class LessonBlankSheet(db.Model):
+    """
+    Feuilles blanches associées à une leçon spécifique (date + période)
+    Similaire à LessonMemo mais pour des pages vierges annotables
+    """
+    __tablename__ = 'lesson_blank_sheets'
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
+    classroom_id = db.Column(db.Integer, db.ForeignKey('classrooms.id'), nullable=True)
+
+    # Date et période de la leçon
+    lesson_date = db.Column(db.Date, nullable=False, index=True)
+    period_number = db.Column(db.Integer, nullable=False, index=True)
+
+    # Titre de la feuille blanche
+    title = db.Column(db.String(200), default="Feuille blanche")
+
+    # Données JSON (pages blanches + annotations)
+    sheet_data = db.Column(db.JSON, nullable=False)
+
+    # Timestamps
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    # Relations
+    user = db.relationship('User', backref=db.backref('blank_sheets', lazy='dynamic'))
+    classroom = db.relationship('Classroom', backref=db.backref('blank_sheets', lazy='dynamic'))
+
+    def __repr__(self):
+        return f'<LessonBlankSheet {self.id}: {self.title} - {self.lesson_date} P{self.period_number}>'
+
+    def to_dict(self):
+        """Retourne un dictionnaire pour l'API"""
+        return {
+            'id': self.id,
+            'title': self.title,
+            'lesson_date': self.lesson_date.isoformat() if self.lesson_date else None,
+            'period_number': self.period_number,
+            'classroom_id': self.classroom_id,
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+            'updated_at': self.updated_at.isoformat() if self.updated_at else None
+        }

--- a/render_production.py
+++ b/render_production.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """
 ProfCalendar - Production App for Render
+Version: 1bc396b - Force Gunicorn reload for template fix
 """
 import os
 from app import create_app

--- a/static/js/clean-pdf-viewer.js
+++ b/static/js/clean-pdf-viewer.js
@@ -6386,6 +6386,17 @@ class CleanPDFViewer {
 
             console.log('[LoadBlankSheet] Données chargées:', sheetData);
 
+            // Charger les annotations AVANT de rendre les pages
+            if (sheetData.annotations) {
+                console.log('[LoadBlankSheet] Chargement annotations pour', Object.keys(sheetData.annotations).length, 'pages');
+
+                for (const [pageId, pageAnnotations] of Object.entries(sheetData.annotations)) {
+                    this.annotations.set(pageId, pageAnnotations);
+                }
+
+                console.log('[LoadBlankSheet] Annotations chargées en mémoire');
+            }
+
             // Charger les pages custom
             if (sheetData.custom_pages && sheetData.custom_pages.length > 0) {
                 console.log('[LoadBlankSheet] Chargement de', sheetData.custom_pages.length, 'pages custom');
@@ -6408,24 +6419,12 @@ class CleanPDFViewer {
                 // Mettre à jour le nombre total de pages
                 this.totalPages = this.pageOrder.length;
 
-                // Rendre les pages
+                // Rendre les pages (les annotations déjà en mémoire seront dessinées automatiquement)
                 await this.renderThumbnails();
                 await this.renderPages();
             } else {
                 // Aucune page custom, créer une page blanche par défaut
                 await this.addBlankPageAfterCurrent();
-            }
-
-            // Charger les annotations
-            if (sheetData.annotations) {
-                console.log('[LoadBlankSheet] Chargement annotations pour', Object.keys(sheetData.annotations).length, 'pages');
-
-                for (const [pageId, pageAnnotations] of Object.entries(sheetData.annotations)) {
-                    this.annotations.set(pageId, pageAnnotations);
-                }
-
-                // Les annotations seront automatiquement redessinées lors du renderPages()
-                console.log('[LoadBlankSheet] Annotations chargées en mémoire');
             }
 
             this.isDirty = false;

--- a/static/js/clean-pdf-viewer.js
+++ b/static/js/clean-pdf-viewer.js
@@ -129,6 +129,8 @@ class CleanPDFViewer {
         if (this.options.pdfUrl) {
             console.log('[Init] Chargement du PDF:', this.options.pdfUrl);
             await this.loadPDF(this.options.pdfUrl);
+        } else {
+            console.log('[Init] Aucun PDF fourni - mode pages blanches');
         }
 
         // Charger les annotations sauvegardées
@@ -138,6 +140,22 @@ class CleanPDFViewer {
             await this.loadAnnotations();
         } else {
             console.log('[Init] Pas de fileId, annotations non chargées');
+        }
+
+        // Si aucune page n'existe après le chargement, créer une première page blanche
+        if (this.pageOrder.length === 0) {
+            console.log('[Init] Aucune page trouvée, création d\'une première page blanche');
+            const newPageId = `blank_${Date.now()}`;
+            this.pages.set(newPageId, {type: 'blank', data: {}});
+            this.pageOrder.push(newPageId);
+            this.totalPages = 1;
+            this.currentPage = newPageId;
+
+            // Re-rendre
+            await this.renderThumbnails();
+            await this.renderPages();
+
+            this.isDirty = true; // Marquer comme modifié pour forcer la première sauvegarde
         }
 
         // Démarrer l'auto-save

--- a/static/js/clean-pdf-viewer.js
+++ b/static/js/clean-pdf-viewer.js
@@ -139,13 +139,17 @@ class CleanPDFViewer {
             console.log('[Init] Aucun PDF fourni - mode pages blanches');
         }
 
-        // Charger les annotations sauvegardées
-        console.log('[Init] Vérification fileId:', this.options.fileId);
-        if (this.options.fileId) {
-            console.log('[Init] Appel de loadAnnotations()...');
+        // Charger les annotations sauvegardées OU la feuille blanche
+        if (this.options.blankSheetId !== null || (this.options.lessonDate && this.options.periodNumber)) {
+            // Mode feuille blanche
+            console.log('[Init] Mode feuille blanche détecté, blankSheetId:', this.options.blankSheetId);
+            await this.loadBlankSheet();
+        } else if (this.options.fileId) {
+            // Mode annotation sur PDF existant
+            console.log('[Init] Mode annotation sur PDF, fileId:', this.options.fileId);
             await this.loadAnnotations();
         } else {
-            console.log('[Init] Pas de fileId, annotations non chargées');
+            console.log('[Init] Pas de fileId ni de blankSheetId, annotations non chargées');
         }
 
         // Si aucune page n'existe après le chargement, créer une première page blanche

--- a/static/js/clean-pdf-viewer.js
+++ b/static/js/clean-pdf-viewer.js
@@ -6327,7 +6327,7 @@ class CleanPDFViewer {
                 }
             };
 
-            const response = await fetch('/api/blank-sheets/save', {
+            const response = await fetch('/planning/api/blank-sheets/save', {
                 method: 'POST',
                 headers: {'Content-Type': 'application/json'},
                 body: JSON.stringify(sheetData)
@@ -6367,7 +6367,7 @@ class CleanPDFViewer {
         try {
             console.log('[LoadBlankSheet] Chargement feuille:', this.options.blankSheetId);
 
-            const response = await fetch(`/api/blank-sheets/${this.options.blankSheetId}`);
+            const response = await fetch(`/planning/api/blank-sheets/${this.options.blankSheetId}`);
 
             if (!response.ok) {
                 console.error('[LoadBlankSheet] Erreur HTTP:', response.status);

--- a/static/js/clean-pdf-viewer.js
+++ b/static/js/clean-pdf-viewer.js
@@ -6408,6 +6408,7 @@ class CleanPDFViewer {
                 const customPagesSorted = sheetData.custom_pages.sort((a, b) => a.position - b.position);
 
                 for (const customPage of customPagesSorted) {
+                    console.log('[LoadBlankSheet] Ajout page:', customPage.pageId, 'type:', customPage.type, 'position:', customPage.position);
                     this.pages.set(customPage.pageId, {
                         type: customPage.type,
                         data: customPage.data || {}
@@ -6422,12 +6423,17 @@ class CleanPDFViewer {
 
                 // Mettre à jour le nombre total de pages
                 this.totalPages = this.pageOrder.length;
+                console.log('[LoadBlankSheet] Total pages:', this.totalPages, 'pageOrder:', this.pageOrder);
 
                 // Rendre les pages (les annotations déjà en mémoire seront dessinées automatiquement)
+                console.log('[LoadBlankSheet] Début rendu thumbnails...');
                 await this.renderThumbnails();
+                console.log('[LoadBlankSheet] Thumbnails rendus, début rendu pages...');
                 await this.renderPages();
+                console.log('[LoadBlankSheet] Pages rendues');
             } else {
                 // Aucune page custom, créer une page blanche par défaut
+                console.log('[LoadBlankSheet] Aucune page custom, création page blanche par défaut');
                 await this.addBlankPageAfterCurrent();
             }
 

--- a/static/js/clean-pdf-viewer.js
+++ b/static/js/clean-pdf-viewer.js
@@ -6633,23 +6633,14 @@ class CleanPDFViewer {
             console.log('[SetSquare] Gestionnaires globaux de blocage retirés');
         }
 
-        // Retirer les gestionnaires pointer de l'équerre
-        if (this.setSquarePointerDownHandler) {
-            document.removeEventListener('pointerdown', this.setSquarePointerDownHandler);
-            this.setSquarePointerDownHandler = null;
-        }
-        if (this.setSquarePointerMoveHandler) {
-            document.removeEventListener('pointermove', this.setSquarePointerMoveHandler);
-            this.setSquarePointerMoveHandler = null;
-        }
-        if (this.setSquarePointerUpHandler) {
-            document.removeEventListener('pointerup', this.setSquarePointerUpHandler);
-            this.setSquarePointerUpHandler = null;
-        }
-        if (this.setSquarePointerCancelHandler) {
-            document.removeEventListener('pointercancel', this.setSquarePointerCancelHandler);
-            this.setSquarePointerCancelHandler = null;
-        }
+        // NOTE: On ne retire PAS les gestionnaires pointer de l'équerre
+        // car ils vérifient déjà this.setSquareActive et retournent immédiatement si false.
+        // Cela évite d'avoir à les réattacher à chaque réactivation de l'équerre.
+        // Les gestionnaires restent attachés mais inactifs quand l'équerre est cachée.
+
+        // CORRECTION BUG: Si on retire les gestionnaires ici, ils ne sont pas réattachés
+        // lors de la réactivation (car showSetSquare() ne les attache que lors de la création initiale).
+        // Résultat: l'équerre ne peut plus tourner ni se déplacer après la première désactivation.
 
         console.log('[SetSquare] Équerre désactivée - scroll/zoom doigts restaurés');
     }

--- a/static/js/clean-pdf-viewer.js
+++ b/static/js/clean-pdf-viewer.js
@@ -260,10 +260,6 @@ class CleanPDFViewer {
                             <i class="fas fa-trash"></i>
                         </button>
                         <div class="separator"></div>
-                        <button class="btn-action" id="btn-add-blank-page" title="Ajouter une page blanche">
-                            <i class="fas fa-file-medical"></i>
-                        </button>
-                        <div class="separator"></div>
                         <button class="btn-action" id="btn-download" title="Télécharger/Envoyer">
                             <i class="fas fa-download"></i>
                         </button>
@@ -332,7 +328,6 @@ class CleanPDFViewer {
             btnUndo: this.container.querySelector('#btn-undo'),
             btnRedo: this.container.querySelector('#btn-redo'),
             btnClearPage: this.container.querySelector('#btn-clear-page'),
-            btnAddBlankPage: this.container.querySelector('#btn-add-blank-page'),
             btnDownload: this.container.querySelector('#btn-download'),
             btnClose: this.container.querySelector('#btn-close'),
             loading: this.container.querySelector('#pdf-loading'),
@@ -1246,7 +1241,6 @@ class CleanPDFViewer {
         this.elements.btnUndo.addEventListener('click', () => this.undo());
         this.elements.btnRedo.addEventListener('click', () => this.redo());
         this.elements.btnClearPage.addEventListener('click', () => this.clearCurrentPage());
-        this.elements.btnAddBlankPage.addEventListener('click', () => this.addBlankPageAfterCurrent());
         this.elements.btnDownload.addEventListener('click', () => this.showDownloadMenu());
         this.elements.btnClose.addEventListener('click', () => this.close());
 

--- a/static/js/clean-pdf-viewer.js
+++ b/static/js/clean-pdf-viewer.js
@@ -6360,7 +6360,7 @@ class CleanPDFViewer {
         if (!this.options.blankSheetId) {
             console.log('[LoadBlankSheet] Pas de blankSheetId, création nouvelle feuille');
             // Créer une première page blanche
-            await this.insertBlankPageAtPosition(0);
+            await this.addBlankPageAfterCurrent();
             return;
         }
 
@@ -6409,7 +6409,7 @@ class CleanPDFViewer {
                 await this.renderAllPages();
             } else {
                 // Aucune page custom, créer une page blanche par défaut
-                await this.insertBlankPageAtPosition(0);
+                await this.addBlankPageAfterCurrent();
             }
 
             // Charger les annotations
@@ -6430,7 +6430,7 @@ class CleanPDFViewer {
         } catch (error) {
             console.error('[LoadBlankSheet] Erreur chargement:', error);
             // En cas d'erreur, créer une page blanche par défaut
-            await this.insertBlankPageAtPosition(0);
+            await this.addBlankPageAfterCurrent();
         }
     }
 

--- a/static/js/clean-pdf-viewer.js
+++ b/static/js/clean-pdf-viewer.js
@@ -6168,13 +6168,7 @@ class CleanPDFViewer {
                         // Ajouter chaque annotation à la page ET à l'historique
                         for (const annotation of pageAnnotations) {
                             // LOG DE DEBUG: Vérifier les dimensions AVANT la migration
-                            console.log(`[Load] DEBUG Annotation AVANT migration pageId ${pageId}:`, {
-                                tool: annotation.tool,
-                                canvasWidth: annotation.canvasWidth,
-                                canvasHeight: annotation.canvasHeight,
-                                hasCanvasWidth: 'canvasWidth' in annotation,
-                                hasCanvasHeight: 'canvasHeight' in annotation
-                            });
+                            console.log(`[Load] DEBUG AVANT migration pageId ${pageId} tool ${annotation.tool}: canvasW=${annotation.canvasWidth} canvasH=${annotation.canvasHeight} hasW=${'canvasWidth' in annotation} hasH=${'canvasHeight' in annotation}`);
 
                             // Migrer les annotations legacy sans canvasWidth/canvasHeight
                             // Assumer qu'elles ont été créées sur un canvas "standard" (viewer plein écran sur /lesson)
@@ -6186,11 +6180,7 @@ class CleanPDFViewer {
                             }
 
                             // LOG DE DEBUG: Vérifier les dimensions APRÈS la migration
-                            console.log(`[Load] DEBUG Annotation APRÈS migration pageId ${pageId}:`, {
-                                tool: annotation.tool,
-                                canvasWidth: annotation.canvasWidth,
-                                canvasHeight: annotation.canvasHeight
-                            });
+                            console.log(`[Load] DEBUG APRÈS migration pageId ${pageId} tool ${annotation.tool}: canvasW=${annotation.canvasWidth} canvasH=${annotation.canvasHeight}`);
 
                             // Ajouter à la Map des annotations
                             this.annotations.get(pageId).push(annotation);
@@ -6285,13 +6275,7 @@ class CleanPDFViewer {
             // LOG DE DEBUG: Vérifier les dimensions des annotations avant sauvegarde
             for (const [pageId, pageAnnotations] of Object.entries(annotationsData)) {
                 for (const ann of pageAnnotations) {
-                    console.log(`[Save] DEBUG Annotation pageId ${pageId}:`, {
-                        tool: ann.tool,
-                        canvasWidth: ann.canvasWidth,
-                        canvasHeight: ann.canvasHeight,
-                        hasCanvasWidth: 'canvasWidth' in ann,
-                        hasCanvasHeight: 'canvasHeight' in ann
-                    });
+                    console.log(`[Save] DEBUG pageId ${pageId} tool ${ann.tool}: canvasW=${ann.canvasWidth} canvasH=${ann.canvasHeight} hasW=${'canvasWidth' in ann} hasH=${'canvasHeight' in ann}`);
                 }
             }
 

--- a/static/js/clean-pdf-viewer.js
+++ b/static/js/clean-pdf-viewer.js
@@ -6167,6 +6167,15 @@ class CleanPDFViewer {
 
                         // Ajouter chaque annotation à la page ET à l'historique
                         for (const annotation of pageAnnotations) {
+                            // LOG DE DEBUG: Vérifier les dimensions AVANT la migration
+                            console.log(`[Load] DEBUG Annotation AVANT migration pageId ${pageId}:`, {
+                                tool: annotation.tool,
+                                canvasWidth: annotation.canvasWidth,
+                                canvasHeight: annotation.canvasHeight,
+                                hasCanvasWidth: 'canvasWidth' in annotation,
+                                hasCanvasHeight: 'canvasHeight' in annotation
+                            });
+
                             // Migrer les annotations legacy sans canvasWidth/canvasHeight
                             // Assumer qu'elles ont été créées sur un canvas "standard" (viewer plein écran sur /lesson)
                             // Taille de référence : PDF A4 à scale ~1.7 = 1200x1697 pixels
@@ -6175,6 +6184,13 @@ class CleanPDFViewer {
                                 annotation.canvasHeight = 1697;
                                 console.log('[Load] Migration annotation legacy - assigné dimensions par défaut:', annotation.canvasWidth, 'x', annotation.canvasHeight);
                             }
+
+                            // LOG DE DEBUG: Vérifier les dimensions APRÈS la migration
+                            console.log(`[Load] DEBUG Annotation APRÈS migration pageId ${pageId}:`, {
+                                tool: annotation.tool,
+                                canvasWidth: annotation.canvasWidth,
+                                canvasHeight: annotation.canvasHeight
+                            });
 
                             // Ajouter à la Map des annotations
                             this.annotations.get(pageId).push(annotation);
@@ -6265,6 +6281,19 @@ class CleanPDFViewer {
             });
 
             console.log('[Save] Sauvegarde de', Object.keys(annotationsData).length, 'pages avec annotations et', customPages.length, 'pages custom');
+
+            // LOG DE DEBUG: Vérifier les dimensions des annotations avant sauvegarde
+            for (const [pageId, pageAnnotations] of Object.entries(annotationsData)) {
+                for (const ann of pageAnnotations) {
+                    console.log(`[Save] DEBUG Annotation pageId ${pageId}:`, {
+                        tool: ann.tool,
+                        canvasWidth: ann.canvasWidth,
+                        canvasHeight: ann.canvasHeight,
+                        hasCanvasWidth: 'canvasWidth' in ann,
+                        hasCanvasHeight: 'canvasHeight' in ann
+                    });
+                }
+            }
 
             const response = await fetch('/file_manager/api/save-annotations', {
                 method: 'POST',

--- a/static/js/clean-pdf-viewer.js
+++ b/static/js/clean-pdf-viewer.js
@@ -242,6 +242,10 @@ class CleanPDFViewer {
                             <i class="fas fa-trash"></i>
                         </button>
                         <div class="separator"></div>
+                        <button class="btn-action" id="btn-add-blank-page" title="Ajouter une page blanche">
+                            <i class="fas fa-file-medical"></i>
+                        </button>
+                        <div class="separator"></div>
                         <button class="btn-action" id="btn-download" title="Télécharger/Envoyer">
                             <i class="fas fa-download"></i>
                         </button>
@@ -310,6 +314,7 @@ class CleanPDFViewer {
             btnUndo: this.container.querySelector('#btn-undo'),
             btnRedo: this.container.querySelector('#btn-redo'),
             btnClearPage: this.container.querySelector('#btn-clear-page'),
+            btnAddBlankPage: this.container.querySelector('#btn-add-blank-page'),
             btnDownload: this.container.querySelector('#btn-download'),
             btnClose: this.container.querySelector('#btn-close'),
             loading: this.container.querySelector('#pdf-loading'),
@@ -1223,6 +1228,7 @@ class CleanPDFViewer {
         this.elements.btnUndo.addEventListener('click', () => this.undo());
         this.elements.btnRedo.addEventListener('click', () => this.redo());
         this.elements.btnClearPage.addEventListener('click', () => this.clearCurrentPage());
+        this.elements.btnAddBlankPage.addEventListener('click', () => this.addBlankPageAfterCurrent());
         this.elements.btnDownload.addEventListener('click', () => this.showDownloadMenu());
         this.elements.btnClose.addEventListener('click', () => this.close());
 
@@ -5219,6 +5225,51 @@ class CleanPDFViewer {
         this.goToPage(newPageId);
 
         this.isDirty = true;
+    }
+
+    /**
+     * Ajouter une page blanche après la page courante
+     */
+    async addBlankPageAfterCurrent() {
+        // Si aucune page n'existe (aucun PDF ouvert), créer une première page blanche
+        if (this.pageOrder.length === 0) {
+            console.log('[AddBlankPage] Aucune page existante, création de la première page blanche');
+
+            // Créer la première page blanche
+            const newPageId = `blank_${Date.now()}`;
+            this.pages.set(newPageId, {type: 'blank', data: {}});
+            this.pageOrder.push(newPageId);
+
+            // Mettre à jour le nombre total de pages
+            this.totalPages = 1;
+
+            // Re-rendre
+            await this.renderThumbnails();
+            await this.renderPages();
+
+            // Naviguer vers la nouvelle page
+            this.goToPage(newPageId);
+
+            this.isDirty = true;
+            return;
+        }
+
+        // Utiliser la page courante ou la dernière page si aucune n'est définie
+        let currentPageId = this.currentPage;
+
+        if (!currentPageId && this.pageOrder.length > 0) {
+            currentPageId = this.pageOrder[this.pageOrder.length - 1];
+        }
+
+        if (!currentPageId) {
+            console.warn('[AddBlankPage] Aucune page disponible');
+            return;
+        }
+
+        console.log('[AddBlankPage] Ajout d\'une page blanche après la page:', currentPageId);
+
+        // Utiliser la méthode existante addPage
+        await this.addPage(currentPageId, 'blank');
     }
 
     /**

--- a/static/js/clean-pdf-viewer.js
+++ b/static/js/clean-pdf-viewer.js
@@ -6405,8 +6405,12 @@ class CleanPDFViewer {
                     }
                 }
 
+                // Mettre à jour le nombre total de pages
+                this.totalPages = this.pageOrder.length;
+
                 // Rendre les pages
-                await this.renderAllPages();
+                await this.renderThumbnails();
+                await this.renderPages();
             } else {
                 // Aucune page custom, créer une page blanche par défaut
                 await this.addBlankPageAfterCurrent();
@@ -6420,8 +6424,8 @@ class CleanPDFViewer {
                     this.annotations.set(pageId, pageAnnotations);
                 }
 
-                // Redessiner les annotations
-                this.redrawAllAnnotations();
+                // Les annotations seront automatiquement redessinées lors du renderPages()
+                console.log('[LoadBlankSheet] Annotations chargées en mémoire');
             }
 
             this.isDirty = false;

--- a/static/js/clean-pdf-viewer.js
+++ b/static/js/clean-pdf-viewer.js
@@ -6702,6 +6702,28 @@ class CleanPDFViewer {
     }
 
     /**
+     * Détruit complètement le viewer sans sauvegarder
+     */
+    destroy() {
+        console.log('[Destroy] Destruction du viewer PDF...');
+
+        // Masquer l'équerre si elle est affichée
+        this.hideSetSquare();
+
+        // Nettoyer les timers et listeners
+        this.stopAutoSave();
+        this.cleanupBeforeUnload();
+
+        // Nettoyer le DOM
+        if (this.container) {
+            this.container.innerHTML = '';
+            this.container.style.display = 'none';
+        }
+
+        console.log('[Destroy] Viewer détruit');
+    }
+
+    /**
      * Afficher l'équerre (set square)
      */
     showSetSquare() {

--- a/templates/planning/calendar_view.html
+++ b/templates/planning/calendar_view.html
@@ -2209,6 +2209,9 @@ if (typeof pdfjsLib !== 'undefined') {
         <div class="modal-header">
             <h3 id="attendanceModalTitle">Présences de la période</h3>
             <div class="modal-header-actions">
+                <button class="btn-icon" onclick="openFileManagerFromAttendance()" title="Fichiers de la classe">
+                    <i class="fas fa-folder-open"></i>
+                </button>
                 <button class="btn-icon" id="attendanceBlankSheetsBtn" onclick="openBlankSheetsFromAttendance()" title="Feuilles blanches" style="display: none;">
                     <i class="fas fa-file"></i>
                 </button>
@@ -6243,6 +6246,14 @@ function escapeHtml(text) {
     return div.innerHTML;
 }
 
+// Fonction pour formater une date ISO en format lisible
+function formatDateTime(isoString) {
+    if (!isoString) return '';
+    const date = new Date(isoString);
+    const options = { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' };
+    return date.toLocaleDateString('fr-FR', options);
+}
+
 // ============ GESTION DES PRÉSENCES POUR PÉRIODES PASSÉES ============
 
 /**
@@ -6385,6 +6396,23 @@ function closeAttendanceModal() {
 }
 
 /**
+ * Ouvre le gestionnaire de fichiers depuis le modal d'attendance
+ */
+function openFileManagerFromAttendance() {
+    if (!window.currentAttendanceContext) {
+        // Si pas de contexte, ouvrir juste le gestionnaire de fichiers
+        window.open('{{ url_for("file_manager.index") }}', '_blank');
+        return;
+    }
+
+    const { classroomId } = window.currentAttendanceContext;
+
+    // Ouvrir le gestionnaire de fichiers dans un nouvel onglet
+    // Si on a l'ID de la classe, on pourrait filtrer par classe (future amélioration)
+    window.open('{{ url_for("file_manager.index") }}', '_blank');
+}
+
+/**
  * Ouvre le menu des feuilles blanches depuis le modal d'attendance (périodes passées)
  */
 async function openBlankSheetsFromAttendance() {
@@ -6458,14 +6486,11 @@ async function showPeriodAttendance(date, periodNumber, classroomId, isMixedGrou
         // Charger les feuilles blanches (toujours)
         await loadBlankSheetsForPeriod(date, periodNumber, classroomId);
 
-        // Charger les présences uniquement si période passée
-        let data = null;
-        if (isPastPeriod) {
-            const response = await fetch(
-                `/planning/get_period_attendance?date=${date}&period=${periodNumber}&classroom_id=${classroomId}&is_mixed_group=${isMixedGroup}`
-            );
-            data = await response.json();
-        }
+        // Charger les données (présences + planification) - toujours appeler pour avoir la planification
+        const response = await fetch(
+            `/planning/get_period_attendance?date=${date}&period=${periodNumber}&classroom_id=${classroomId}&is_mixed_group=${isMixedGroup}`
+        );
+        const data = await response.json();
 
         // Masquer l'état de chargement
         document.getElementById('attendanceLoadingState').style.display = 'none';
@@ -6480,8 +6505,17 @@ async function showPeriodAttendance(date, periodNumber, classroomId, isMixedGrou
         document.getElementById('allPresentMessage').style.display = 'none';
         document.getElementById('attendanceErrorMessage').style.display = 'none';
 
-        // Si période future, ne pas traiter les présences
+        // Pour les périodes futures, afficher uniquement la planification (pas les présences)
         if (!isPastPeriod) {
+            // Afficher la planification si elle existe
+            if (data && data.planning) {
+                const planning = data.planning;
+                if (planning.title || planning.description) {
+                    document.getElementById('planningTitle').textContent = planning.title || '';
+                    document.getElementById('planningDescription').textContent = planning.description || '';
+                    document.getElementById('planningSection').style.display = 'block';
+                }
+            }
             return;
         }
 

--- a/templates/planning/calendar_view.html
+++ b/templates/planning/calendar_view.html
@@ -2422,15 +2422,21 @@ if (typeof pdfjsLib !== 'undefined') {
 {% endblock %}
 
 {% block extra_js %}
-<script src="{{ url_for('static', filename='js/planning.js') }}"></script>
-<script src="{{ url_for('static', filename='js/unified-pdf-viewer.js') }}?v=NATIVE20250923&cache_bust={{ range(1000000, 9999999) | random }}&native=true&nopf=true&simple=drawing"></script>
 <script>
+// Définir les variables globales AVANT de charger planning.js qui les utilise
 const currentWeek = '{{ current_week.strftime("%Y-%m-%d") }}';
 const selectedClassroomId = {{ selected_classroom_id|tojson if selected_classroom_id else 'null' }};
 const periodsData = {{ periods_json | tojson }};
 const classrooms = {{ classrooms_json | tojson }};
 const scheduleGrid = {{ schedule_grid_json | tojson }};
 const mergedInfo = {{ merged_info | tojson }};
+</script>
+
+<!-- Charger planning.js APRÈS avoir défini les variables globales -->
+<script src="{{ url_for('static', filename='js/planning.js') }}"></script>
+<script src="{{ url_for('static', filename='js/unified-pdf-viewer.js') }}?v=NATIVE20250923&cache_bust={{ range(1000000, 9999999) | random }}&native=true&nopf=true&simple=drawing"></script>
+
+<script>
 let currentPlanningCell = null;
 let isExtendedView = false;
 

--- a/templates/planning/calendar_view.html
+++ b/templates/planning/calendar_view.html
@@ -1533,6 +1533,83 @@ if (typeof pdfjsLib !== 'undefined') {
 #pdf-viewer-container-calendar button[data-tool="eraser"] {
     order: 2 !important;
 }
+
+/* Styles pour le menu de sélection des feuilles blanches */
+.blank-sheets-menu {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: white;
+    padding: 1.5rem;
+    border-radius: 0.5rem;
+    box-shadow: 0 10px 40px rgba(0,0,0,0.2);
+    z-index: 12000;
+    min-width: 400px;
+    max-width: 500px;
+}
+
+.blank-sheets-menu .menu-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+.blank-sheets-menu .menu-header h4 {
+    margin: 0;
+    font-size: 1.125rem;
+    color: #1f2937;
+}
+
+.blank-sheets-menu .menu-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.blank-sheets-menu .sheet-item {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem;
+    border-radius: 0.375rem;
+    cursor: pointer;
+    transition: background-color 0.2s;
+    border: 1px solid #e5e7eb;
+}
+
+.blank-sheets-menu .sheet-item:hover {
+    background-color: #f3f4f6;
+}
+
+.blank-sheets-menu .sheet-item i {
+    color: #f59e0b;
+    font-size: 1.25rem;
+}
+
+.blank-sheets-menu .sheet-item span {
+    flex: 1;
+    font-weight: 500;
+    color: #1f2937;
+}
+
+.blank-sheets-menu .sheet-item small {
+    color: #6b7280;
+    font-size: 0.75rem;
+}
+
+/* Style pour les feuilles blanches dans la liste de fichiers */
+.file-item.blank-sheet {
+    background-color: #fef3c7;
+    border-left: 3px solid #f59e0b;
+}
+
+.file-item.blank-sheet .file-icon {
+    color: #f59e0b;
+}
 </style>
 {% endblock %}
 
@@ -2319,6 +2396,11 @@ const mergedInfo = {{ merged_info | tojson }};
 let currentPlanningCell = null;
 let isExtendedView = false;
 
+// Variables globales pour le contexte modal actuel (pour feuilles blanches)
+let currentModalDate = null;
+let currentModalPeriod = null;
+let currentModalClassroomId = null;
+
 // Variables globales pour les mises à jour dynamiques
 window.selectedClassroomId = selectedClassroomId;
 window.classroomsData = classrooms;
@@ -2730,6 +2812,7 @@ async function loadClassFiles(classroomId) {
     pinnedResources.style.display = 'none';
 
     try {
+        // Charger les fichiers de la classe
         const response = await fetch(`/planning/get-class-resources/${numericId}`);
         console.log('Réponse API:', response);
 
@@ -2739,6 +2822,20 @@ async function loadClassFiles(classroomId) {
 
         const data = await response.json();
         console.log('Données reçues:', data);
+
+        // Charger les feuilles blanches si on a une date et période
+        currentBlankSheets = []; // Réinitialiser
+        if (currentModalDate && currentModalPeriod && numericId) {
+            try {
+                const blankResponse = await fetch(`/api/blank-sheets/list?date=${currentModalDate}&period=${currentModalPeriod}&classroom_id=${numericId}`);
+                const blankData = await blankResponse.json();
+                if (blankData.success && blankData.sheets) {
+                    currentBlankSheets = blankData.sheets;
+                }
+            } catch (error) {
+                console.warn('Erreur lors du chargement des feuilles blanches:', error);
+            }
+        }
 
         fileLoading.style.display = 'none';
 
@@ -2753,7 +2850,12 @@ async function loadClassFiles(classroomId) {
             allClassFiles = data.files;
             fileNavigation.style.display = 'block';
             fileTree.style.display = 'block';
-            renderFileTree(data.files, currentFilePath);
+            renderFileTree(data.files, currentFilePath, currentBlankSheets);
+        } else if (currentBlankSheets.length > 0) {
+            // Afficher seulement les feuilles blanches si pas de fichiers
+            fileNavigation.style.display = 'block';
+            fileTree.style.display = 'block';
+            renderFileTree([], currentFilePath, currentBlankSheets);
         } else if (!data.pinned_files || data.pinned_files.length === 0) {
             console.log('Aucun fichier trouvé ou erreur dans la réponse');
             noFiles.style.display = 'block';
@@ -2842,10 +2944,34 @@ function formatFileSize(bytes) {
 }
 
 // Afficher l'arborescence des fichiers
-function renderFileTree(files, currentPath = '') {
+function renderFileTree(files, currentPath = '', blankSheets = []) {
     const fileTree = document.getElementById('fileTree');
     fileTree.innerHTML = '';
-    
+
+    // Afficher les feuilles blanches en premier (seulement à la racine)
+    if (!currentPath && blankSheets && blankSheets.length > 0) {
+        const blankSheetsSection = document.createElement('div');
+        blankSheetsSection.className = 'blank-sheets-section';
+        blankSheetsSection.innerHTML = '<h4 style="font-size: 0.875rem; font-weight: 600; color: #6b7280; margin: 0.5rem 0; padding: 0.5rem; border-bottom: 1px solid #e5e7eb;"><i class="fas fa-file"></i> Feuilles blanches</h4>';
+
+        blankSheets.forEach(sheet => {
+            const sheetItem = document.createElement('div');
+            sheetItem.className = 'file-item blank-sheet';
+            sheetItem.innerHTML = `
+                <div class="file-clickable-area" style="display: flex; align-items: center; flex: 1; cursor: pointer;" onclick="openExistingBlankSheetCalendar(${sheet.id})">
+                    <i class="fas fa-file file-icon"></i>
+                    <div class="file-info">
+                        <span class="file-name">${escapeHtmlCalendar(sheet.title)}</span>
+                        <small style="color: #6b7280; font-size: 0.75rem;">${formatDateTimeCalendar(sheet.created_at)}</small>
+                    </div>
+                </div>
+            `;
+            blankSheetsSection.appendChild(sheetItem);
+        });
+
+        fileTree.appendChild(blankSheetsSection);
+    }
+
     // Organiser les fichiers par dossier
     const folders = {};
     const currentLevelFiles = [];
@@ -2971,6 +3097,7 @@ function renderFileTree(files, currentPath = '') {
 
 // Variable globale pour stocker tous les fichiers
 let allClassFiles = [];
+let currentBlankSheets = []; // Pour stocker les feuilles blanches de la période en cours
 
 // Obtenir l'icône appropriée pour un type de fichier
 function getFileIconByType(fileType) {
@@ -2991,9 +3118,10 @@ function getFileIconByType(fileType) {
 function navigateToFolder(folderPath) {
     currentFilePath = folderPath;
     console.log('Navigation vers le dossier:', folderPath);
-    
+
     // Re-render l'arbre avec le nouveau chemin
-    renderFileTree(allClassFiles, folderPath);
+    // Afficher les feuilles blanches seulement à la racine
+    renderFileTree(allClassFiles, folderPath, folderPath === '' ? currentBlankSheets : []);
 }
 
 // Mettre à jour le fil d'Ariane
@@ -3115,10 +3243,173 @@ async function openPdfInViewer(fileId, fileName) {
 }
 
 // Ouvrir le viewer avec des pages blanches (mode split 50%)
+/**
+ * Affiche le menu de sélection des feuilles blanches pour la leçon en cours
+ */
 async function openBlankPagesCalendar() {
-    console.log('📄 Ouverture du viewer avec des pages blanches');
+    console.log('📄 Ouverture du menu des feuilles blanches');
+
+    // Vérifier qu'on a les informations nécessaires
+    if (!currentModalDate || !currentModalPeriod) {
+        alert('Veuillez d\'abord sélectionner une date et une période');
+        return;
+    }
+
+    // Récupérer l'ID de la classe sélectionnée dans le modal
+    const modalClassroom = document.getElementById('modalClassroom');
+    if (!modalClassroom || !modalClassroom.value) {
+        alert('Veuillez d\'abord sélectionner une classe');
+        return;
+    }
+
+    // Extraire l'ID numérique de la classe
+    let classroomId = null;
+    const classroomValue = modalClassroom.value;
+    if (classroomValue.startsWith('classroom_')) {
+        classroomId = classroomValue.replace('classroom_', '');
+    } else if (classroomValue.startsWith('mixed_group_')) {
+        classroomId = classroomValue.replace('mixed_group_', '');
+    } else {
+        alert('Type de classe non supporté');
+        return;
+    }
 
     try {
+        // Charger les feuilles blanches existantes
+        const response = await fetch(`/api/blank-sheets/list?date=${currentModalDate}&period=${currentModalPeriod}&classroom_id=${classroomId}`);
+        const data = await response.json();
+
+        if (data.sheets && data.sheets.length === 0) {
+            // Aucune feuille existante, créer directement
+            openNewBlankSheetCalendar(currentModalDate, currentModalPeriod, classroomId);
+        } else {
+            // Afficher menu de sélection
+            displayBlankSheetsMenuCalendar(data.sheets, currentModalDate, currentModalPeriod, classroomId);
+        }
+    } catch (error) {
+        console.error('Erreur lors du chargement des feuilles blanches:', error);
+        alert('Erreur lors du chargement des feuilles blanches');
+    }
+}
+
+/**
+ * Affiche un menu pour sélectionner une feuille blanche existante ou en créer une nouvelle
+ */
+function displayBlankSheetsMenuCalendar(sheets, lessonDate, periodNumber, classroomId) {
+    // Créer le menu modal
+    const menu = document.createElement('div');
+    menu.className = 'blank-sheets-menu';
+    menu.innerHTML = `
+        <div class="menu-header">
+            <h4>Feuilles blanches de la leçon</h4>
+            <button onclick="this.parentElement.parentElement.remove()" style="background: none; border: none; font-size: 1.5rem; cursor: pointer; color: #6B7280;">×</button>
+        </div>
+        <div class="menu-list" style="max-height: 300px; overflow-y: auto; margin: 1rem 0;">
+            ${sheets.map(sheet => `
+                <div class="sheet-item" onclick="openExistingBlankSheetCalendar(${sheet.id}); this.parentElement.parentElement.parentElement.remove();">
+                    <i class="fas fa-file"></i>
+                    <span>${escapeHtmlCalendar(sheet.title)}</span>
+                    <small>${formatDateTimeCalendar(sheet.created_at)}</small>
+                </div>
+            `).join('')}
+        </div>
+        <button class="btn-primary" onclick="openNewBlankSheetCalendar('${lessonDate}', ${periodNumber}, ${classroomId}); this.parentElement.remove();" style="width: 100%; margin-top: 1rem;">
+            <i class="fas fa-plus"></i> Nouvelle feuille
+        </button>
+    `;
+
+    document.body.appendChild(menu);
+}
+
+/**
+ * Ouvre une nouvelle feuille blanche
+ */
+async function openNewBlankSheetCalendar(lessonDate, periodNumber, classroomId) {
+    console.log('📄 Création nouvelle feuille blanche');
+
+    const container = document.getElementById('pdf-viewer-container-calendar');
+    if (!container) {
+        console.error('❌ Conteneur PDF non trouvé');
+        return;
+    }
+
+    // Afficher le conteneur
+    container.style.display = 'block';
+
+    // Détruire l'instance précédente si elle existe
+    if (window.cleanPDFViewerCalendar) {
+        window.cleanPDFViewerCalendar.destroy();
+        window.cleanPDFViewerCalendar = null;
+    }
+
+    // Vider le conteneur
+    container.innerHTML = '';
+
+    // Récupérer les étudiants de la classe actuelle si disponible
+    let studentsData = [];
+    try {
+        if (classroomId) {
+            studentsData = await getStudentsForClass(classroomId);
+        }
+    } catch (error) {
+        console.warn('⚠️ Impossible de récupérer les étudiants:', error);
+    }
+
+    // Créer l'instance du nouveau lecteur clean pour pages blanches
+    window.cleanPDFViewerCalendar = new CleanPDFViewer('pdf-viewer-container-calendar', {
+        blankSheetId: null, // Nouvelle feuille
+        lessonDate: lessonDate,
+        periodNumber: periodNumber,
+        classroomId: classroomId,
+        title: 'Feuille blanche',
+        pdfUrl: null,
+        showSidebar: true,
+        enableAnnotations: true,
+        autoSaveInterval: 5000,
+        annotationOffsetY: -10,
+        annotationScaleMultiplier: 1.05,
+        studentData: studentsData,
+        onClose: () => {
+            container.style.display = 'none';
+            window.cleanPDFViewerCalendar = null;
+            // Recharger les fichiers pour afficher la nouvelle feuille
+            const modalClassroom = document.getElementById('modalClassroom');
+            if (modalClassroom && modalClassroom.value) {
+                const classroomValue = modalClassroom.value;
+                let id = null;
+                if (classroomValue.startsWith('classroom_')) {
+                    id = classroomValue.replace('classroom_', '');
+                } else if (classroomValue.startsWith('mixed_group_')) {
+                    id = classroomValue.replace('mixed_group_', '');
+                }
+                if (id) {
+                    loadClassFiles(id);
+                }
+            }
+        }
+    });
+
+    console.log('✅ Nouvelle feuille blanche créée');
+}
+
+/**
+ * Ouvre une feuille blanche existante
+ */
+async function openExistingBlankSheetCalendar(sheetId) {
+    console.log('📄 Ouverture feuille blanche:', sheetId);
+
+    try {
+        // Charger les données de la feuille
+        const response = await fetch(`/api/blank-sheets/${sheetId}`);
+        const data = await response.json();
+
+        if (!data.success) {
+            alert('Erreur lors du chargement de la feuille: ' + (data.message || 'Erreur inconnue'));
+            return;
+        }
+
+        const sheet = data.sheet;
+
         const container = document.getElementById('pdf-viewer-container-calendar');
         if (!container) {
             console.error('❌ Conteneur PDF non trouvé');
@@ -3137,27 +3428,24 @@ async function openBlankPagesCalendar() {
         // Vider le conteneur
         container.innerHTML = '';
 
-        // Créer un ID spécial pour les pages blanches basé sur la classe et la période
-        let blankPagesId = 'blank_calendar';
-        if (selectedClassroomId) {
-            // Si une classe est sélectionnée, utiliser son ID
-            blankPagesId = `blank_calendar_${selectedClassroomId}`;
-        }
-
         // Récupérer les étudiants de la classe actuelle si disponible
         let studentsData = [];
         try {
-            if (selectedClassroomId) {
-                studentsData = await getStudentsForClass(selectedClassroomId);
+            if (sheet.classroom_id) {
+                studentsData = await getStudentsForClass(sheet.classroom_id);
             }
         } catch (error) {
             console.warn('⚠️ Impossible de récupérer les étudiants:', error);
         }
 
-        // Créer l'instance du nouveau lecteur clean pour pages blanches
+        // Créer l'instance du nouveau lecteur clean
         window.cleanPDFViewerCalendar = new CleanPDFViewer('pdf-viewer-container-calendar', {
-            fileId: blankPagesId, // ID spécial pour sauvegarder les pages blanches
-            pdfUrl: null, // Pas de PDF à charger
+            blankSheetId: sheet.id,
+            lessonDate: sheet.lesson_date,
+            periodNumber: sheet.period_number,
+            classroomId: sheet.classroom_id,
+            title: sheet.title,
+            pdfUrl: null,
             showSidebar: true,
             enableAnnotations: true,
             autoSaveInterval: 5000,
@@ -3167,14 +3455,51 @@ async function openBlankPagesCalendar() {
             onClose: () => {
                 container.style.display = 'none';
                 window.cleanPDFViewerCalendar = null;
+                // Recharger les fichiers pour afficher les modifications
+                const modalClassroom = document.getElementById('modalClassroom');
+                if (modalClassroom && modalClassroom.value) {
+                    const classroomValue = modalClassroom.value;
+                    let id = null;
+                    if (classroomValue.startsWith('classroom_')) {
+                        id = classroomValue.replace('classroom_', '');
+                    } else if (classroomValue.startsWith('mixed_group_')) {
+                        id = classroomValue.replace('mixed_group_', '');
+                    }
+                    if (id) {
+                        loadClassFiles(id);
+                    }
+                }
             }
         });
 
-        console.log('✅ Viewer avec pages blanches créé, ID:', blankPagesId);
+        console.log('✅ Feuille blanche chargée');
     } catch (error) {
-        console.error('❌ Erreur lors de la création du viewer:', error);
-        alert('Erreur lors de la création du viewer: ' + error.message);
+        console.error('Erreur lors du chargement de la feuille blanche:', error);
+        alert('Erreur lors du chargement de la feuille blanche');
     }
+}
+
+/**
+ * Fonction utilitaire pour échapper le HTML (calendar version)
+ */
+function escapeHtmlCalendar(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+}
+
+/**
+ * Fonction utilitaire pour formater la date/heure (calendar version)
+ */
+function formatDateTimeCalendar(dateString) {
+    if (!dateString) return '';
+    const date = new Date(dateString);
+    const day = String(date.getDate()).padStart(2, '0');
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const year = date.getFullYear();
+    const hours = String(date.getHours()).padStart(2, '0');
+    const minutes = String(date.getMinutes()).padStart(2, '0');
+    return `${day}/${month}/${year} ${hours}:${minutes}`;
 }
 
 // Charger un document PDF (copié de lesson_view.html)
@@ -3910,6 +4235,10 @@ document.addEventListener('DOMContentLoaded', function() {
         window.openPlanningModal = function(cell, fromAnnualView = false) {
             const date = cell.dataset.date;
             const period = cell.dataset.period;
+
+            // Stocker le contexte modal pour les feuilles blanches
+            currentModalDate = date;
+            currentModalPeriod = period ? period.split('-')[0] : null; // Prendre le premier numéro pour périodes fusionnées
 
             console.log('🔍 openPlanningModal intercepted:', {
                 date,

--- a/templates/planning/calendar_view.html
+++ b/templates/planning/calendar_view.html
@@ -2225,6 +2225,26 @@ if (typeof pdfjsLib !== 'undefined') {
             </div>
 
             <div id="attendanceContent" style="display: none;">
+                <!-- Feuilles blanches -->
+                <div id="blankSheetsSection" style="margin-bottom: 1.5rem;">
+                    <h4 style="color: #f59e0b; margin-bottom: 0.75rem; font-size: 1rem; display: flex; align-items: center; justify-content: space-between;">
+                        <span>
+                            <i class="fas fa-file" style="margin-right: 0.5rem;"></i>
+                            Feuilles blanches (<span id="blankSheetsCount">0</span>)
+                        </span>
+                        <button class="btn btn-sm btn-primary" onclick="createNewBlankSheetFromModal()" style="padding: 0.25rem 0.75rem; font-size: 0.875rem;">
+                            <i class="fas fa-plus"></i> Nouvelle
+                        </button>
+                    </h4>
+                    <div id="blankSheetsList" style="display: grid; gap: 0.5rem;">
+                        <!-- Les feuilles blanches seront ajoutées ici -->
+                    </div>
+                    <div id="noBlankSheetsMessage" style="display: none; text-align: center; padding: 1rem; background: #fef3c7; border-radius: 0.5rem; color: #92400e;">
+                        <i class="fas fa-info-circle" style="margin-right: 0.5rem;"></i>
+                        Aucune feuille blanche pour cette période
+                    </div>
+                </div>
+
                 <!-- Planification de la période -->
                 <div id="planningSection" style="display: none; margin-bottom: 1.5rem;">
                     <h4 style="color: var(--primary-color); margin-bottom: 0.75rem; font-size: 1rem; display: flex; align-items: center;">
@@ -6251,6 +6271,86 @@ function escapeHtml(text) {
 
 // ============ GESTION DES PRÉSENCES POUR PÉRIODES PASSÉES ============
 
+/**
+ * Charge les feuilles blanches pour une période
+ */
+async function loadBlankSheetsForPeriod(date, periodNumber, classroomId) {
+    try {
+        const response = await fetch(`/planning/api/blank-sheets/list?date=${date}&period=${periodNumber}&classroom_id=${classroomId}`);
+        const data = await response.json();
+
+        const blankSheetsList = document.getElementById('blankSheetsList');
+        const noBlankSheetsMessage = document.getElementById('noBlankSheetsMessage');
+        const blankSheetsCount = document.getElementById('blankSheetsCount');
+
+        if (data.success && data.sheets && data.sheets.length > 0) {
+            // Afficher les feuilles blanches
+            blankSheetsList.innerHTML = '';
+            data.sheets.forEach(sheet => {
+                const sheetItem = document.createElement('div');
+                sheetItem.className = 'blank-sheet-item';
+                sheetItem.style.cssText = 'padding: 0.75rem 1rem; background: #fef3c7; border-radius: 0.5rem; display: flex; justify-content: space-between; align-items: center; border-left: 4px solid #f59e0b; cursor: pointer;';
+                sheetItem.innerHTML = `
+                    <div style="display: flex; align-items: center; gap: 0.75rem;">
+                        <i class="fas fa-file" style="color: #f59e0b;"></i>
+                        <div>
+                            <div style="font-weight: 500; color: #78350f;">${sheet.title}</div>
+                            <div style="font-size: 0.875rem; color: #92400e;">${formatDateTime(sheet.created_at)}</div>
+                        </div>
+                    </div>
+                    <button class="btn btn-sm" onclick="event.stopPropagation(); openBlankSheetFromModal(${sheet.id})" style="padding: 0.25rem 0.5rem;">
+                        <i class="fas fa-eye"></i>
+                    </button>
+                `;
+                sheetItem.onclick = () => openBlankSheetFromModal(sheet.id);
+                blankSheetsList.appendChild(sheetItem);
+            });
+
+            blankSheetsList.style.display = 'grid';
+            noBlankSheetsMessage.style.display = 'none';
+            blankSheetsCount.textContent = data.sheets.length;
+        } else {
+            // Aucune feuille blanche
+            blankSheetsList.style.display = 'none';
+            noBlankSheetsMessage.style.display = 'block';
+            blankSheetsCount.textContent = '0';
+        }
+    } catch (error) {
+        console.error('Erreur lors du chargement des feuilles blanches:', error);
+    }
+}
+
+/**
+ * Crée une nouvelle feuille blanche depuis le modal de période
+ */
+function createNewBlankSheetFromModal() {
+    if (!window.currentAttendanceContext) {
+        alert('Contexte de période non disponible');
+        return;
+    }
+
+    const { date, periodNumber, classroomId } = window.currentAttendanceContext;
+
+    // Fermer le modal de période
+    closeAttendanceModal();
+
+    // Ouvrir le viewer avec une nouvelle feuille blanche
+    openNewBlankSheetCalendar(date, periodNumber, classroomId);
+}
+
+/**
+ * Ouvre une feuille blanche existante depuis le modal
+ */
+async function openBlankSheetFromModal(sheetId) {
+    console.log('📄 Ouverture feuille blanche depuis modal:', sheetId);
+
+    // Fermer le modal de période
+    closeAttendanceModal();
+
+    // Ouvrir la feuille blanche existante
+    openExistingBlankSheetCalendar(sheetId);
+}
+
 function closeAttendanceModal() {
     const modal = document.getElementById('attendanceModal');
     const overlay = document.getElementById('modalOverlay');
@@ -6288,15 +6388,6 @@ async function openBlankSheetsFromAttendance() {
 }
 
 async function showPeriodAttendance(date, periodNumber, classroomId, isMixedGroup, periodTitle) {
-    // Vérifier que la période est dans le passé
-    const periodDate = new Date(date);
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-
-    if (periodDate > today) {
-        return; // Ne rien faire si la période n'est pas encore passée
-    }
-
     // Ouvrir le modal
     const modal = document.getElementById('attendanceModal');
     const overlay = document.getElementById('modalOverlay');
@@ -6310,7 +6401,7 @@ async function showPeriodAttendance(date, periodNumber, classroomId, isMixedGrou
         month: 'long',
         day: 'numeric'
     });
-    modalTitle.textContent = `Présences - ${periodTitle || 'Période ' + periodNumber} - ${formattedDate}`;
+    modalTitle.textContent = `${periodTitle || 'Période ' + periodNumber} - ${formattedDate}`;
 
     // Stocker les informations pour le bouton feuilles blanches
     window.currentAttendanceContext = {
@@ -6319,10 +6410,10 @@ async function showPeriodAttendance(date, periodNumber, classroomId, isMixedGrou
         classroomId: classroomId
     };
 
-    // Afficher le bouton feuilles blanches
+    // Masquer le bouton feuilles blanches (maintenant intégré dans la modal)
     const blankSheetsBtn = document.getElementById('attendanceBlankSheetsBtn');
     if (blankSheetsBtn) {
-        blankSheetsBtn.style.display = 'block';
+        blankSheetsBtn.style.display = 'none';
     }
 
     // Afficher le modal avec l'état de chargement
@@ -6331,22 +6422,24 @@ async function showPeriodAttendance(date, periodNumber, classroomId, isMixedGrou
     modal.style.display = 'block';
     overlay.style.display = 'block';
 
+    // Vérifier que la période est dans le passé pour charger les présences
+    const periodDate = new Date(date);
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const isPastPeriod = periodDate <= today;
+
     try {
-        // Appeler l'API
-        const response = await fetch(
-            `/planning/get_period_attendance?date=${date}&period=${periodNumber}&classroom_id=${classroomId}&is_mixed_group=${isMixedGroup}`
-        );
+        // Charger les feuilles blanches (toujours)
+        await loadBlankSheetsForPeriod(date, periodNumber, classroomId);
 
-        const data = await response.json();
-
-        if (!data.success) {
-            showAttendanceError(data.error || 'Erreur lors du chargement des présences');
-            return;
+        // Charger les présences uniquement si période passée
+        let data = null;
+        if (isPastPeriod) {
+            const response = await fetch(
+                `/planning/get_period_attendance?date=${date}&period=${periodNumber}&classroom_id=${classroomId}&is_mixed_group=${isMixedGroup}`
+            );
+            data = await response.json();
         }
-
-        // Filtrer les élèves par statut
-        const absentStudents = data.students.filter(s => s.status === 'absent');
-        const lateStudents = data.students.filter(s => s.status === 'late');
 
         // Masquer l'état de chargement
         document.getElementById('attendanceLoadingState').style.display = 'none';
@@ -6360,6 +6453,20 @@ async function showPeriodAttendance(date, periodNumber, classroomId, isMixedGrou
         document.getElementById('lateStudentsSection').style.display = 'none';
         document.getElementById('allPresentMessage').style.display = 'none';
         document.getElementById('attendanceErrorMessage').style.display = 'none';
+
+        // Si période future, ne pas traiter les présences
+        if (!isPastPeriod) {
+            return;
+        }
+
+        if (!data || !data.success) {
+            showAttendanceError(data?.error || 'Erreur lors du chargement des présences');
+            return;
+        }
+
+        // Filtrer les élèves par statut
+        const absentStudents = data.students.filter(s => s.status === 'absent');
+        const lateStudents = data.students.filter(s => s.status === 'late');
 
         // Afficher la planification si elle existe
         if (data.planning) {

--- a/templates/planning/calendar_view.html
+++ b/templates/planning/calendar_view.html
@@ -2208,9 +2208,14 @@ if (typeof pdfjsLib !== 'undefined') {
     <div class="modal-content" id="attendanceModalContent">
         <div class="modal-header">
             <h3 id="attendanceModalTitle">Présences de la période</h3>
-            <button class="modal-close" onclick="closeAttendanceModal()">
-                <i class="fas fa-times"></i>
-            </button>
+            <div class="modal-header-actions">
+                <button class="btn-icon" id="attendanceBlankSheetsBtn" onclick="openBlankSheetsFromAttendance()" title="Feuilles blanches" style="display: none;">
+                    <i class="fas fa-file"></i>
+                </button>
+                <button class="modal-close" onclick="closeAttendanceModal()">
+                    <i class="fas fa-times"></i>
+                </button>
+            </div>
         </div>
 
         <div class="modal-body">
@@ -6253,6 +6258,35 @@ function closeAttendanceModal() {
     overlay.style.display = 'none';
 }
 
+/**
+ * Ouvre le menu des feuilles blanches depuis le modal d'attendance (périodes passées)
+ */
+async function openBlankSheetsFromAttendance() {
+    if (!window.currentAttendanceContext) {
+        alert('Contexte de période non disponible');
+        return;
+    }
+
+    const { date, periodNumber, classroomId } = window.currentAttendanceContext;
+
+    try {
+        // Charger les feuilles blanches existantes
+        const response = await fetch(`/planning/api/blank-sheets/list?date=${date}&period=${periodNumber}&classroom_id=${classroomId}`);
+        const data = await response.json();
+
+        if (data.sheets && data.sheets.length === 0) {
+            // Aucune feuille existante, créer directement
+            openNewBlankSheetCalendar(date, periodNumber, classroomId);
+        } else {
+            // Afficher menu de sélection
+            displayBlankSheetsMenuCalendar(data.sheets, date, periodNumber, classroomId);
+        }
+    } catch (error) {
+        console.error('Erreur lors du chargement des feuilles blanches:', error);
+        alert('Erreur lors du chargement des feuilles blanches');
+    }
+}
+
 async function showPeriodAttendance(date, periodNumber, classroomId, isMixedGroup, periodTitle) {
     // Vérifier que la période est dans le passé
     const periodDate = new Date(date);
@@ -6277,6 +6311,19 @@ async function showPeriodAttendance(date, periodNumber, classroomId, isMixedGrou
         day: 'numeric'
     });
     modalTitle.textContent = `Présences - ${periodTitle || 'Période ' + periodNumber} - ${formattedDate}`;
+
+    // Stocker les informations pour le bouton feuilles blanches
+    window.currentAttendanceContext = {
+        date: date,
+        periodNumber: periodNumber,
+        classroomId: classroomId
+    };
+
+    // Afficher le bouton feuilles blanches
+    const blankSheetsBtn = document.getElementById('attendanceBlankSheetsBtn');
+    if (blankSheetsBtn) {
+        blankSheetsBtn.style.display = 'block';
+    }
 
     // Afficher le modal avec l'état de chargement
     document.getElementById('attendanceLoadingState').style.display = 'block';

--- a/templates/planning/calendar_view.html
+++ b/templates/planning/calendar_view.html
@@ -2827,7 +2827,7 @@ async function loadClassFiles(classroomId) {
         currentBlankSheets = []; // Réinitialiser
         if (currentModalDate && currentModalPeriod && numericId) {
             try {
-                const blankResponse = await fetch(`/api/blank-sheets/list?date=${currentModalDate}&period=${currentModalPeriod}&classroom_id=${numericId}`);
+                const blankResponse = await fetch(`/planning/api/blank-sheets/list?date=${currentModalDate}&period=${currentModalPeriod}&classroom_id=${numericId}`);
                 const blankData = await blankResponse.json();
                 if (blankData.success && blankData.sheets) {
                     currentBlankSheets = blankData.sheets;
@@ -3276,7 +3276,7 @@ async function openBlankPagesCalendar() {
 
     try {
         // Charger les feuilles blanches existantes
-        const response = await fetch(`/api/blank-sheets/list?date=${currentModalDate}&period=${currentModalPeriod}&classroom_id=${classroomId}`);
+        const response = await fetch(`/planning/api/blank-sheets/list?date=${currentModalDate}&period=${currentModalPeriod}&classroom_id=${classroomId}`);
         const data = await response.json();
 
         if (data.sheets && data.sheets.length === 0) {
@@ -3400,7 +3400,7 @@ async function openExistingBlankSheetCalendar(sheetId) {
 
     try {
         // Charger les données de la feuille
-        const response = await fetch(`/api/blank-sheets/${sheetId}`);
+        const response = await fetch(`/planning/api/blank-sheets/${sheetId}`);
         const data = await response.json();
 
         if (!data.success) {

--- a/templates/planning/calendar_view.html
+++ b/templates/planning/calendar_view.html
@@ -6291,18 +6291,22 @@ async function loadBlankSheetsForPeriod(date, periodNumber, classroomId) {
                 sheetItem.className = 'blank-sheet-item';
                 sheetItem.style.cssText = 'padding: 0.75rem 1rem; background: #fef3c7; border-radius: 0.5rem; display: flex; justify-content: space-between; align-items: center; border-left: 4px solid #f59e0b; cursor: pointer;';
                 sheetItem.innerHTML = `
-                    <div style="display: flex; align-items: center; gap: 0.75rem;">
+                    <div onclick="openBlankSheetFromModal(${sheet.id})" style="display: flex; align-items: center; gap: 0.75rem; flex: 1; cursor: pointer;">
                         <i class="fas fa-file" style="color: #f59e0b;"></i>
                         <div>
                             <div style="font-weight: 500; color: #78350f;">${sheet.title}</div>
                             <div style="font-size: 0.875rem; color: #92400e;">${formatDateTime(sheet.created_at)}</div>
                         </div>
                     </div>
-                    <button class="btn btn-sm" onclick="event.stopPropagation(); openBlankSheetFromModal(${sheet.id})" style="padding: 0.25rem 0.5rem;">
-                        <i class="fas fa-eye"></i>
-                    </button>
+                    <div style="display: flex; gap: 0.5rem;">
+                        <button class="btn btn-sm" onclick="event.stopPropagation(); openBlankSheetFromModal(${sheet.id})" style="padding: 0.25rem 0.5rem; background: #3b82f6; color: white; border: none; border-radius: 0.375rem; cursor: pointer;" title="Ouvrir">
+                            <i class="fas fa-eye"></i>
+                        </button>
+                        <button class="btn btn-sm" onclick="event.stopPropagation(); deleteBlankSheetFromModal(${sheet.id})" style="padding: 0.25rem 0.5rem; background: #dc2626; color: white; border: none; border-radius: 0.375rem; cursor: pointer;" title="Supprimer">
+                            <i class="fas fa-trash"></i>
+                        </button>
+                    </div>
                 `;
-                sheetItem.onclick = () => openBlankSheetFromModal(sheet.id);
                 blankSheetsList.appendChild(sheetItem);
             });
 
@@ -6349,6 +6353,41 @@ async function openBlankSheetFromModal(sheetId) {
 
     // Ouvrir la feuille blanche existante
     openExistingBlankSheetCalendar(sheetId);
+}
+
+/**
+ * Supprime une feuille blanche depuis le modal
+ */
+async function deleteBlankSheetFromModal(sheetId) {
+    console.log('🗑️ Suppression feuille blanche:', sheetId);
+
+    // Confirmer la suppression
+    if (!confirm('Êtes-vous sûr de vouloir supprimer cette feuille blanche ? Cette action est irréversible.')) {
+        return;
+    }
+
+    try {
+        const response = await fetch(`/planning/api/blank-sheets/${sheetId}`, {
+            method: 'DELETE',
+            headers: {'Content-Type': 'application/json'}
+        });
+
+        const data = await response.json();
+
+        if (data.success) {
+            console.log('✅ Feuille blanche supprimée');
+            // Recharger la liste des feuilles blanches
+            if (window.currentAttendanceContext) {
+                const { date, periodNumber, classroomId } = window.currentAttendanceContext;
+                await loadBlankSheetsForPeriod(date, periodNumber, classroomId);
+            }
+        } else {
+            alert('Erreur lors de la suppression: ' + (data.message || 'Erreur inconnue'));
+        }
+    } catch (error) {
+        console.error('Erreur lors de la suppression de la feuille blanche:', error);
+        alert('Erreur lors de la suppression de la feuille blanche');
+    }
 }
 
 function closeAttendanceModal() {

--- a/templates/planning/calendar_view.html
+++ b/templates/planning/calendar_view.html
@@ -2875,12 +2875,7 @@ async function loadClassFiles(classroomId) {
             allClassFiles = data.files;
             fileNavigation.style.display = 'block';
             fileTree.style.display = 'block';
-            renderFileTree(data.files, currentFilePath, currentBlankSheets);
-        } else if (currentBlankSheets.length > 0) {
-            // Afficher seulement les feuilles blanches si pas de fichiers
-            fileNavigation.style.display = 'block';
-            fileTree.style.display = 'block';
-            renderFileTree([], currentFilePath, currentBlankSheets);
+            renderFileTree(data.files, currentFilePath);
         } else if (!data.pinned_files || data.pinned_files.length === 0) {
             console.log('Aucun fichier trouvé ou erreur dans la réponse');
             noFiles.style.display = 'block';
@@ -2969,33 +2964,12 @@ function formatFileSize(bytes) {
 }
 
 // Afficher l'arborescence des fichiers
-function renderFileTree(files, currentPath = '', blankSheets = []) {
+function renderFileTree(files, currentPath = '') {
     const fileTree = document.getElementById('fileTree');
     fileTree.innerHTML = '';
 
-    // Afficher les feuilles blanches en premier (seulement à la racine)
-    if (!currentPath && blankSheets && blankSheets.length > 0) {
-        const blankSheetsSection = document.createElement('div');
-        blankSheetsSection.className = 'blank-sheets-section';
-        blankSheetsSection.innerHTML = '<h4 style="font-size: 0.875rem; font-weight: 600; color: #6b7280; margin: 0.5rem 0; padding: 0.5rem; border-bottom: 1px solid #e5e7eb;"><i class="fas fa-file"></i> Feuilles blanches</h4>';
-
-        blankSheets.forEach(sheet => {
-            const sheetItem = document.createElement('div');
-            sheetItem.className = 'file-item blank-sheet';
-            sheetItem.innerHTML = `
-                <div class="file-clickable-area" style="display: flex; align-items: center; flex: 1; cursor: pointer;" onclick="openExistingBlankSheetCalendar(${sheet.id})">
-                    <i class="fas fa-file file-icon"></i>
-                    <div class="file-info">
-                        <span class="file-name">${escapeHtmlCalendar(sheet.title)}</span>
-                        <small style="color: #6b7280; font-size: 0.75rem;">${formatDateTimeCalendar(sheet.created_at)}</small>
-                    </div>
-                </div>
-            `;
-            blankSheetsSection.appendChild(sheetItem);
-        });
-
-        fileTree.appendChild(blankSheetsSection);
-    }
+    // Note: Les feuilles blanches sont maintenant affichées uniquement dans le modal de période
+    // (pas dans le file-manager-panel)
 
     // Organiser les fichiers par dossier
     const folders = {};

--- a/templates/planning/calendar_view.html
+++ b/templates/planning/calendar_view.html
@@ -1983,9 +1983,14 @@ if (typeof pdfjsLib !== 'undefined') {
     <div class="file-manager-panel" id="fileManagerPanel" style="display: none;">
         <div class="file-manager-header">
             <h3><i class="fas fa-folder-open"></i> Fichiers de la classe</h3>
-            <button class="btn-icon" onclick="toggleSplitView()" title="Fermer">
-                <i class="fas fa-times"></i>
-            </button>
+            <div style="display: flex; gap: 0.5rem;">
+                <button class="btn-icon" onclick="openBlankPagesCalendar()" title="Créer des feuilles blanches">
+                    <i class="fas fa-file-medical"></i>
+                </button>
+                <button class="btn-icon" onclick="toggleSplitView()" title="Fermer">
+                    <i class="fas fa-times"></i>
+                </button>
+            </div>
         </div>
         <div class="file-manager-content" id="fileManagerContent">
             <!-- Chargement initial -->
@@ -3106,6 +3111,69 @@ async function openPdfInViewer(fileId, fileName) {
     } catch (error) {
         console.error('❌ Erreur lors du chargement du PDF:', error);
         alert('Erreur lors du chargement du PDF: ' + error.message);
+    }
+}
+
+// Ouvrir le viewer avec des pages blanches (mode split 50%)
+async function openBlankPagesCalendar() {
+    console.log('📄 Ouverture du viewer avec des pages blanches');
+
+    try {
+        const container = document.getElementById('pdf-viewer-container-calendar');
+        if (!container) {
+            console.error('❌ Conteneur PDF non trouvé');
+            return;
+        }
+
+        // Afficher le conteneur
+        container.style.display = 'block';
+
+        // Détruire l'instance précédente si elle existe
+        if (window.cleanPDFViewerCalendar) {
+            window.cleanPDFViewerCalendar.destroy();
+            window.cleanPDFViewerCalendar = null;
+        }
+
+        // Vider le conteneur
+        container.innerHTML = '';
+
+        // Créer un ID spécial pour les pages blanches basé sur la classe et la période
+        let blankPagesId = 'blank_calendar';
+        if (selectedClassroomId) {
+            // Si une classe est sélectionnée, utiliser son ID
+            blankPagesId = `blank_calendar_${selectedClassroomId}`;
+        }
+
+        // Récupérer les étudiants de la classe actuelle si disponible
+        let studentsData = [];
+        try {
+            if (selectedClassroomId) {
+                studentsData = await getStudentsForClass(selectedClassroomId);
+            }
+        } catch (error) {
+            console.warn('⚠️ Impossible de récupérer les étudiants:', error);
+        }
+
+        // Créer l'instance du nouveau lecteur clean pour pages blanches
+        window.cleanPDFViewerCalendar = new CleanPDFViewer('pdf-viewer-container-calendar', {
+            fileId: blankPagesId, // ID spécial pour sauvegarder les pages blanches
+            pdfUrl: null, // Pas de PDF à charger
+            showSidebar: true,
+            enableAnnotations: true,
+            autoSaveInterval: 5000,
+            annotationOffsetY: -10,
+            annotationScaleMultiplier: 1.05,
+            studentData: studentsData,
+            onClose: () => {
+                container.style.display = 'none';
+                window.cleanPDFViewerCalendar = null;
+            }
+        });
+
+        console.log('✅ Viewer avec pages blanches créé, ID:', blankPagesId);
+    } catch (error) {
+        console.error('❌ Erreur lors de la création du viewer:', error);
+        alert('Erreur lors de la création du viewer: ' + error.message);
     }
 }
 

--- a/templates/planning/calendar_view.html
+++ b/templates/planning/calendar_view.html
@@ -3387,21 +3387,28 @@ async function openNewBlankSheetCalendar(lessonDate, periodNumber, classroomId) 
         annotationOffsetY: -10,
         annotationScaleMultiplier: 1.05,
         studentData: studentsData,
-        onClose: () => {
+        onClose: async () => {
             container.style.display = 'none';
             window.cleanPDFViewerCalendar = null;
-            // Recharger les fichiers pour afficher la nouvelle feuille
-            const modalClassroom = document.getElementById('modalClassroom');
-            if (modalClassroom && modalClassroom.value) {
-                const classroomValue = modalClassroom.value;
-                let id = null;
-                if (classroomValue.startsWith('classroom_')) {
-                    id = classroomValue.replace('classroom_', '');
-                } else if (classroomValue.startsWith('mixed_group_')) {
-                    id = classroomValue.replace('mixed_group_', '');
-                }
-                if (id) {
-                    loadClassFiles(id);
+
+            // Si on est dans le contexte d'un modal de planification, recharger la liste des feuilles blanches
+            if (window.currentPlanningContext) {
+                const { date, periodNumber, classroomId } = window.currentPlanningContext;
+                await loadBlankSheetsForPlanningModal(date, periodNumber, classroomId);
+            } else {
+                // Sinon recharger les fichiers de la classe (comportement original)
+                const modalClassroom = document.getElementById('modalClassroom');
+                if (modalClassroom && modalClassroom.value) {
+                    const classroomValue = modalClassroom.value;
+                    let id = null;
+                    if (classroomValue.startsWith('classroom_')) {
+                        id = classroomValue.replace('classroom_', '');
+                    } else if (classroomValue.startsWith('mixed_group_')) {
+                        id = classroomValue.replace('mixed_group_', '');
+                    }
+                    if (id) {
+                        loadClassFiles(id);
+                    }
                 }
             }
         }
@@ -3470,21 +3477,28 @@ async function openExistingBlankSheetCalendar(sheetId) {
             annotationOffsetY: -10,
             annotationScaleMultiplier: 1.05,
             studentData: studentsData,
-            onClose: () => {
+            onClose: async () => {
                 container.style.display = 'none';
                 window.cleanPDFViewerCalendar = null;
-                // Recharger les fichiers pour afficher les modifications
-                const modalClassroom = document.getElementById('modalClassroom');
-                if (modalClassroom && modalClassroom.value) {
-                    const classroomValue = modalClassroom.value;
-                    let id = null;
-                    if (classroomValue.startsWith('classroom_')) {
-                        id = classroomValue.replace('classroom_', '');
-                    } else if (classroomValue.startsWith('mixed_group_')) {
-                        id = classroomValue.replace('mixed_group_', '');
-                    }
-                    if (id) {
-                        loadClassFiles(id);
+
+                // Si on est dans le contexte d'un modal de planification, recharger la liste des feuilles blanches
+                if (window.currentPlanningContext) {
+                    const { date, periodNumber, classroomId } = window.currentPlanningContext;
+                    await loadBlankSheetsForPlanningModal(date, periodNumber, classroomId);
+                } else {
+                    // Sinon recharger les fichiers de la classe (comportement original)
+                    const modalClassroom = document.getElementById('modalClassroom');
+                    if (modalClassroom && modalClassroom.value) {
+                        const classroomValue = modalClassroom.value;
+                        let id = null;
+                        if (classroomValue.startsWith('classroom_')) {
+                            id = classroomValue.replace('classroom_', '');
+                        } else if (classroomValue.startsWith('mixed_group_')) {
+                            id = classroomValue.replace('mixed_group_', '');
+                        }
+                        if (id) {
+                            loadClassFiles(id);
+                        }
                     }
                 }
             }
@@ -6390,8 +6404,13 @@ async function deleteBlankSheetFromModal(sheetId) {
 
         if (data.success) {
             console.log('✅ Feuille blanche supprimée');
-            // Recharger la liste des feuilles blanches
-            if (window.currentAttendanceContext) {
+            // Recharger la liste des feuilles blanches selon le contexte
+            if (window.currentPlanningContext) {
+                // Dans le modal de planification (périodes futures)
+                const { date, periodNumber, classroomId } = window.currentPlanningContext;
+                await loadBlankSheetsForPlanningModal(date, periodNumber, classroomId);
+            } else if (window.currentAttendanceContext) {
+                // Dans le modal d'attendance (périodes passées)
                 const { date, periodNumber, classroomId } = window.currentAttendanceContext;
                 await loadBlankSheetsForPeriod(date, periodNumber, classroomId);
             }
@@ -6580,14 +6599,14 @@ async function savePlanning() {
         console.log('💾 Sauvegarde planification période:', {date, periodNumber, classroomSelectValue, title});
 
         try {
-            const response = await fetch('/planning/save', {
+            const response = await fetch('/planning/save_planning', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
                 },
                 body: JSON.stringify({
                     date: date,
-                    period: periodNumber,
+                    period_number: periodNumber,
                     classroom_id: classroomSelectValue,
                     title: title,
                     description: description,

--- a/templates/planning/calendar_view.html
+++ b/templates/planning/calendar_view.html
@@ -6249,15 +6249,26 @@ function escapeHtml(text) {
  * Charge les feuilles blanches pour une période
  */
 async function loadBlankSheetsForPeriod(date, periodNumber, classroomId) {
+    console.log('📄 loadBlankSheetsForPeriod appelée - date:', date, 'période:', periodNumber, 'classe:', classroomId);
+
     try {
         const response = await fetch(`/planning/api/blank-sheets/list?date=${date}&period=${periodNumber}&classroom_id=${classroomId}`);
         const data = await response.json();
+
+        console.log('📋 loadBlankSheetsForPeriod: Données reçues:', data);
 
         const blankSheetsList = document.getElementById('blankSheetsList');
         const noBlankSheetsMessage = document.getElementById('noBlankSheetsMessage');
         const blankSheetsCount = document.getElementById('blankSheetsCount');
 
+        console.log('🔍 Éléments DOM trouvés:', {
+            blankSheetsList: !!blankSheetsList,
+            noBlankSheetsMessage: !!noBlankSheetsMessage,
+            blankSheetsCount: !!blankSheetsCount
+        });
+
         if (data.success && data.sheets && data.sheets.length > 0) {
+            console.log('✅ loadBlankSheetsForPeriod: Affichage de', data.sheets.length, 'feuilles blanches');
             // Afficher les feuilles blanches
             blankSheetsList.innerHTML = '';
             data.sheets.forEach(sheet => {
@@ -6287,14 +6298,16 @@ async function loadBlankSheetsForPeriod(date, periodNumber, classroomId) {
             blankSheetsList.style.display = 'grid';
             noBlankSheetsMessage.style.display = 'none';
             blankSheetsCount.textContent = data.sheets.length;
+            console.log('✅ loadBlankSheetsForPeriod: Liste affichée avec', data.sheets.length, 'feuilles');
         } else {
             // Aucune feuille blanche
+            console.log('ℹ️ loadBlankSheetsForPeriod: Aucune feuille blanche, affichage du message');
             blankSheetsList.style.display = 'none';
             noBlankSheetsMessage.style.display = 'block';
             blankSheetsCount.textContent = '0';
         }
     } catch (error) {
-        console.error('Erreur lors du chargement des feuilles blanches:', error);
+        console.error('❌ Erreur lors du chargement des feuilles blanches:', error);
     }
 }
 

--- a/templates/planning/calendar_view.html
+++ b/templates/planning/calendar_view.html
@@ -2046,6 +2046,22 @@ if (typeof pdfjsLib !== 'undefined') {
                     <!-- Les mémos seront insérés ici par JavaScript -->
                 </div>
             </div>
+
+            <!-- Section feuilles blanches -->
+            <div class="form-group" id="modalBlankSheetsSection" style="display: none; margin-top: 20px;">
+                <h4 style="color: #f59e0b; margin-bottom: 0.75rem; font-size: 1rem; display: flex; align-items: center; justify-content: space-between;">
+                    <span>
+                        <i class="fas fa-file" style="margin-right: 0.5rem;"></i>
+                        Feuilles blanches (<span id="modalBlankSheetsCount">0</span>)
+                    </span>
+                    <button type="button" class="btn btn-sm btn-primary" onclick="createNewBlankSheetFromPlanningModal()" style="padding: 0.25rem 0.75rem; font-size: 0.875rem;">
+                        <i class="fas fa-plus"></i> Nouvelle
+                    </button>
+                </h4>
+                <div id="modalBlankSheetsList" style="display: grid; gap: 0.5rem;">
+                    <!-- Les feuilles blanches seront ajoutées ici -->
+                </div>
+            </div>
         </div>
 
         <div class="modal-footer">
@@ -2209,12 +2225,6 @@ if (typeof pdfjsLib !== 'undefined') {
         <div class="modal-header">
             <h3 id="attendanceModalTitle">Présences de la période</h3>
             <div class="modal-header-actions">
-                <button class="btn-icon" onclick="openFileManagerFromAttendance()" title="Fichiers de la classe">
-                    <i class="fas fa-folder-open"></i>
-                </button>
-                <button class="btn-icon" id="attendanceBlankSheetsBtn" onclick="openBlankSheetsFromAttendance()" title="Feuilles blanches" style="display: none;">
-                    <i class="fas fa-file"></i>
-                </button>
                 <button class="modal-close" onclick="closeAttendanceModal()">
                     <i class="fas fa-times"></i>
                 </button>
@@ -6398,51 +6408,132 @@ function closeAttendanceModal() {
 /**
  * Ouvre le gestionnaire de fichiers depuis le modal d'attendance
  */
-function openFileManagerFromAttendance() {
-    if (!window.currentAttendanceContext) {
-        // Si pas de contexte, ouvrir juste le gestionnaire de fichiers
-        window.open('{{ url_for("file_manager.index") }}', '_blank');
-        return;
+/**
+ * Charge les feuilles blanches pour le planningModal
+ */
+async function loadBlankSheetsForPlanningModal(date, periodNumber, classroomId) {
+    console.log('📄 loadBlankSheetsForPlanningModal - date:', date, 'période:', periodNumber);
+
+    try {
+        const response = await fetch(`/planning/api/blank-sheets/list?date=${date}&period=${periodNumber}&classroom_id=${classroomId}`);
+        const data = await response.json();
+
+        const blankSheetsList = document.getElementById('modalBlankSheetsList');
+        const blankSheetsCount = document.getElementById('modalBlankSheetsCount');
+        const blankSheetsSection = document.getElementById('modalBlankSheetsSection');
+
+        if (data.success && data.sheets && data.sheets.length > 0) {
+            console.log('✅ Affichage de', data.sheets.length, 'feuilles blanches dans planningModal');
+            blankSheetsList.innerHTML = '';
+            blankSheetsCount.textContent = data.sheets.length;
+
+            data.sheets.forEach(sheet => {
+                const sheetItem = document.createElement('div');
+                sheetItem.className = 'blank-sheet-item';
+                sheetItem.style.cssText = 'padding: 0.75rem 1rem; background: #fef3c7; border-radius: 0.5rem; display: flex; justify-content: space-between; align-items: center; border-left: 4px solid #f59e0b; cursor: pointer;';
+                sheetItem.innerHTML = `
+                    <div onclick="openBlankSheetFromModal(${sheet.id})" style="display: flex; align-items: center; gap: 0.75rem; flex: 1; cursor: pointer;">
+                        <i class="fas fa-file" style="color: #f59e0b;"></i>
+                        <div>
+                            <div style="font-weight: 500; color: #78350f;">${sheet.title}</div>
+                            <div style="font-size: 0.875rem; color: #92400e;">${formatDateTime(sheet.created_at)}</div>
+                        </div>
+                    </div>
+                    <button class="btn btn-sm" onclick="event.stopPropagation(); deleteBlankSheetFromModal(${sheet.id})" style="padding: 0.25rem 0.5rem; background: #ef4444; color: white; border: none; border-radius: 0.375rem; cursor: pointer;" title="Supprimer">
+                        <i class="fas fa-trash"></i>
+                    </button>
+                `;
+                blankSheetsList.appendChild(sheetItem);
+            });
+
+            blankSheetsSection.style.display = 'block';
+        } else {
+            console.log('ℹ️ Aucune feuille blanche pour cette période');
+            blankSheetsCount.textContent = '0';
+            blankSheetsList.innerHTML = '';
+            blankSheetsSection.style.display = 'block';
+        }
+    } catch (error) {
+        console.error('❌ Erreur lors du chargement des feuilles blanches:', error);
     }
-
-    const { classroomId } = window.currentAttendanceContext;
-
-    // Ouvrir le gestionnaire de fichiers dans un nouvel onglet
-    // Si on a l'ID de la classe, on pourrait filtrer par classe (future amélioration)
-    window.open('{{ url_for("file_manager.index") }}', '_blank');
 }
 
 /**
- * Ouvre le menu des feuilles blanches depuis le modal d'attendance (périodes passées)
+ * Crée une nouvelle feuille blanche depuis le planningModal
  */
-async function openBlankSheetsFromAttendance() {
-    if (!window.currentAttendanceContext) {
+function createNewBlankSheetFromPlanningModal() {
+    if (!window.currentPlanningContext) {
         alert('Contexte de période non disponible');
         return;
     }
 
-    const { date, periodNumber, classroomId } = window.currentAttendanceContext;
-
-    try {
-        // Charger les feuilles blanches existantes
-        const response = await fetch(`/planning/api/blank-sheets/list?date=${date}&period=${periodNumber}&classroom_id=${classroomId}`);
-        const data = await response.json();
-
-        if (data.sheets && data.sheets.length === 0) {
-            // Aucune feuille existante, créer directement
-            openNewBlankSheetCalendar(date, periodNumber, classroomId);
-        } else {
-            // Afficher menu de sélection
-            displayBlankSheetsMenuCalendar(data.sheets, date, periodNumber, classroomId);
-        }
-    } catch (error) {
-        console.error('Erreur lors du chargement des feuilles blanches:', error);
-        alert('Erreur lors du chargement des feuilles blanches');
-    }
+    const { date, periodNumber, classroomId } = window.currentPlanningContext;
+    openNewBlankSheetCalendar(date, periodNumber, classroomId);
 }
 
+/**
+ * Ouvre le modal de planification pour une période spécifique (périodes futures)
+ */
+async function openPeriodPlanningModal(date, periodNumber, classroomId, isMixedGroup, periodTitle) {
+    console.log('📝 Ouverture modal planification pour période:', {date, periodNumber, classroomId});
+
+    const modal = document.getElementById('planningModal');
+    const overlay = document.getElementById('modalOverlay');
+    const modalTitleElem = document.getElementById('modalTitle');
+
+    // Mettre à jour le titre
+    const dateObj = new Date(date);
+    const formattedDate = dateObj.toLocaleDateString('fr-FR', {
+        weekday: 'long',
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric'
+    });
+    modalTitleElem.textContent = `${periodTitle || 'Période ' + periodNumber} - ${formattedDate}`;
+
+    // Stocker le contexte pour la sauvegarde
+    window.currentPlanningContext = {
+        date: date,
+        periodNumber: periodNumber,
+        classroomId: classroomId,
+        isMixedGroup: isMixedGroup
+    };
+
+    // Pré-sélectionner la classe
+    const classroomSelect = document.getElementById('modalClassroom');
+    const classroomValue = isMixedGroup ? `mixed_group_${classroomId}` : `classroom_${classroomId}`;
+    classroomSelect.value = classroomValue;
+
+    // Charger les groupes si c'est une classe normale
+    if (!isMixedGroup) {
+        await loadGroupsForClass(classroomValue);
+    }
+
+    // Charger les feuilles blanches pour cette période
+    await loadBlankSheetsForPlanningModal(date, periodNumber, classroomId);
+
+    // Afficher le modal
+    modal.style.display = 'block';
+    overlay.style.display = 'block';
+}
+
+/**
+ * Affiche le modal de présences pour les périodes passées OU le modal de planification pour les périodes futures
+ */
 async function showPeriodAttendance(date, periodNumber, classroomId, isMixedGroup, periodTitle) {
-    // Ouvrir le modal
+    // Vérifier si la période est dans le passé
+    const periodDate = new Date(date);
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const isPastPeriod = periodDate <= today;
+
+    // Pour les périodes futures, ouvrir le modal de planification
+    if (!isPastPeriod) {
+        await openPeriodPlanningModal(date, periodNumber, classroomId, isMixedGroup, periodTitle);
+        return;
+    }
+
+    // Pour les périodes passées, afficher le modal de présences
     const modal = document.getElementById('attendanceModal');
     const overlay = document.getElementById('modalOverlay');
     const modalTitle = document.getElementById('attendanceModalTitle');
@@ -6457,18 +6548,12 @@ async function showPeriodAttendance(date, periodNumber, classroomId, isMixedGrou
     });
     modalTitle.textContent = `${periodTitle || 'Période ' + periodNumber} - ${formattedDate}`;
 
-    // Stocker les informations pour le bouton feuilles blanches
+    // Stocker les informations pour les feuilles blanches
     window.currentAttendanceContext = {
         date: date,
         periodNumber: periodNumber,
         classroomId: classroomId
     };
-
-    // Masquer le bouton feuilles blanches (maintenant intégré dans la modal)
-    const blankSheetsBtn = document.getElementById('attendanceBlankSheetsBtn');
-    if (blankSheetsBtn) {
-        blankSheetsBtn.style.display = 'none';
-    }
 
     // Afficher le modal avec l'état de chargement
     document.getElementById('attendanceLoadingState').style.display = 'block';

--- a/templates/planning/calendar_view.html
+++ b/templates/planning/calendar_view.html
@@ -4276,8 +4276,8 @@ document.addEventListener('DOMContentLoaded', function() {
                 return;
             }
 
-            // Si la période est passée ET qu'il y a une classe/groupe, afficher les présences
-            if (periodDate < today && (defaultClassroom || defaultMixedGroup)) {
+            // Si il y a une classe/groupe, afficher le modal de période (présences + feuilles blanches)
+            if (defaultClassroom || defaultMixedGroup) {
                 // Extraire l'ID et le type de la classe/groupe
                 let classroomId = null;
                 let isMixedGroup = false;

--- a/templates/planning/calendar_view.html
+++ b/templates/planning/calendar_view.html
@@ -6561,11 +6561,8 @@ async function showPeriodAttendance(date, periodNumber, classroomId, isMixedGrou
     modal.style.display = 'block';
     overlay.style.display = 'block';
 
-    // Vérifier que la période est dans le passé pour charger les présences
-    const periodDate = new Date(date);
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    const isPastPeriod = periodDate <= today;
+    // Note: isPastPeriod est déjà vérifié au début de la fonction (ligne 6528)
+    // On est ici seulement pour les périodes passées
 
     try {
         // Charger les feuilles blanches (toujours)
@@ -6595,9 +6592,9 @@ async function showPeriodAttendance(date, periodNumber, classroomId, isMixedGrou
             return;
         }
 
-        // Filtrer les élèves par statut (seulement pour périodes passées)
-        const absentStudents = isPastPeriod ? data.students.filter(s => s.status === 'absent') : [];
-        const lateStudents = isPastPeriod ? data.students.filter(s => s.status === 'late') : [];
+        // Filtrer les élèves par statut
+        const absentStudents = data.students.filter(s => s.status === 'absent');
+        const lateStudents = data.students.filter(s => s.status === 'late');
 
         // Afficher la planification si elle existe
         if (data.planning) {
@@ -6664,14 +6661,13 @@ async function showPeriodAttendance(date, periodNumber, classroomId, isMixedGrou
             }
         }
 
-        // Afficher les présences uniquement pour les périodes passées
-        if (isPastPeriod) {
-            if (absentStudents.length === 0 && lateStudents.length === 0) {
-                // Tous présents
-                document.getElementById('allPresentMessage').style.display = 'block';
-            } else {
-                // Afficher les élèves absents
-                if (absentStudents.length > 0) {
+        // Afficher les présences (on est toujours sur une période passée ici)
+        if (absentStudents.length === 0 && lateStudents.length === 0) {
+            // Tous présents
+            document.getElementById('allPresentMessage').style.display = 'block';
+        } else {
+            // Afficher les élèves absents
+            if (absentStudents.length > 0) {
                 document.getElementById('absentCount').textContent = absentStudents.length;
                 const absentList = document.getElementById('absentStudentsList');
                 absentList.innerHTML = '';
@@ -6706,7 +6702,6 @@ async function showPeriodAttendance(date, periodNumber, classroomId, isMixedGrou
                 });
 
                 document.getElementById('lateStudentsSection').style.display = 'block';
-            }
             }
         }
 

--- a/templates/planning/calendar_view.html
+++ b/templates/planning/calendar_view.html
@@ -6505,28 +6505,14 @@ async function showPeriodAttendance(date, periodNumber, classroomId, isMixedGrou
         document.getElementById('allPresentMessage').style.display = 'none';
         document.getElementById('attendanceErrorMessage').style.display = 'none';
 
-        // Pour les périodes futures, afficher uniquement la planification (pas les présences)
-        if (!isPastPeriod) {
-            // Afficher la planification si elle existe
-            if (data && data.planning) {
-                const planning = data.planning;
-                if (planning.title || planning.description) {
-                    document.getElementById('planningTitle').textContent = planning.title || '';
-                    document.getElementById('planningDescription').textContent = planning.description || '';
-                    document.getElementById('planningSection').style.display = 'block';
-                }
-            }
-            return;
-        }
-
         if (!data || !data.success) {
             showAttendanceError(data?.error || 'Erreur lors du chargement des présences');
             return;
         }
 
-        // Filtrer les élèves par statut
-        const absentStudents = data.students.filter(s => s.status === 'absent');
-        const lateStudents = data.students.filter(s => s.status === 'late');
+        // Filtrer les élèves par statut (seulement pour périodes passées)
+        const absentStudents = isPastPeriod ? data.students.filter(s => s.status === 'absent') : [];
+        const lateStudents = isPastPeriod ? data.students.filter(s => s.status === 'late') : [];
 
         // Afficher la planification si elle existe
         if (data.planning) {
@@ -6593,12 +6579,14 @@ async function showPeriodAttendance(date, periodNumber, classroomId, isMixedGrou
             }
         }
 
-        if (absentStudents.length === 0 && lateStudents.length === 0) {
-            // Tous présents
-            document.getElementById('allPresentMessage').style.display = 'block';
-        } else {
-            // Afficher les élèves absents
-            if (absentStudents.length > 0) {
+        // Afficher les présences uniquement pour les périodes passées
+        if (isPastPeriod) {
+            if (absentStudents.length === 0 && lateStudents.length === 0) {
+                // Tous présents
+                document.getElementById('allPresentMessage').style.display = 'block';
+            } else {
+                // Afficher les élèves absents
+                if (absentStudents.length > 0) {
                 document.getElementById('absentCount').textContent = absentStudents.length;
                 const absentList = document.getElementById('absentStudentsList');
                 absentList.innerHTML = '';
@@ -6633,6 +6621,7 @@ async function showPeriodAttendance(date, periodNumber, classroomId, isMixedGrou
                 });
 
                 document.getElementById('lateStudentsSection').style.display = 'block';
+            }
             }
         }
 

--- a/templates/planning/calendar_view.html
+++ b/templates/planning/calendar_view.html
@@ -3384,8 +3384,8 @@ async function openNewBlankSheetCalendar(lessonDate, periodNumber, classroomId) 
         showSidebar: true,
         enableAnnotations: true,
         autoSaveInterval: 5000,
-        annotationOffsetY: -10,
-        annotationScaleMultiplier: 1.05,
+        // Pour les feuilles blanches, laisser le système automatique calculer le redimensionnement
+        // (les paramètres annotationOffsetY et annotationScaleMultiplier sont désactivés)
         studentData: studentsData,
         onClose: async () => {
             container.style.display = 'none';
@@ -3474,8 +3474,8 @@ async function openExistingBlankSheetCalendar(sheetId) {
             showSidebar: true,
             enableAnnotations: true,
             autoSaveInterval: 5000,
-            annotationOffsetY: -10,
-            annotationScaleMultiplier: 1.05,
+            // Pour les feuilles blanches, laisser le système automatique calculer le redimensionnement
+            // (les paramètres annotationOffsetY et annotationScaleMultiplier sont désactivés)
             studentData: studentsData,
             onClose: async () => {
                 container.style.display = 'none';

--- a/templates/planning/calendar_view.html
+++ b/templates/planning/calendar_view.html
@@ -1982,6 +1982,22 @@ if (typeof pdfjsLib !== 'undefined') {
         </div>
 
         <div class="modal-body">
+            <!-- Section feuilles blanches (en premier) -->
+            <div class="form-group" id="modalBlankSheetsSection" style="display: none; margin-bottom: 1.5rem;">
+                <h4 style="color: #f59e0b; margin-bottom: 0.75rem; font-size: 1rem; display: flex; align-items: center; justify-content: space-between;">
+                    <span>
+                        <i class="fas fa-file" style="margin-right: 0.5rem;"></i>
+                        Feuilles blanches (<span id="modalBlankSheetsCount">0</span>)
+                    </span>
+                    <button type="button" class="btn btn-sm btn-primary" onclick="createNewBlankSheetFromPlanningModal()" style="padding: 0.25rem 0.75rem; font-size: 0.875rem;">
+                        <i class="fas fa-plus"></i> Nouvelle
+                    </button>
+                </h4>
+                <div id="modalBlankSheetsList" style="display: grid; gap: 0.5rem;">
+                    <!-- Les feuilles blanches seront ajoutées ici -->
+                </div>
+            </div>
+
             <div class="form-group">
                 <label class="form-label">Classe</label>
                 <select id="modalClassroom" class="form-control" onchange="loadGroupsForClass(this.value)">
@@ -2044,22 +2060,6 @@ if (typeof pdfjsLib !== 'undefined') {
                 </label>
                 <div id="modalMemosList" style="margin-top: 10px;">
                     <!-- Les mémos seront insérés ici par JavaScript -->
-                </div>
-            </div>
-
-            <!-- Section feuilles blanches -->
-            <div class="form-group" id="modalBlankSheetsSection" style="display: none; margin-top: 20px;">
-                <h4 style="color: #f59e0b; margin-bottom: 0.75rem; font-size: 1rem; display: flex; align-items: center; justify-content: space-between;">
-                    <span>
-                        <i class="fas fa-file" style="margin-right: 0.5rem;"></i>
-                        Feuilles blanches (<span id="modalBlankSheetsCount">0</span>)
-                    </span>
-                    <button type="button" class="btn btn-sm btn-primary" onclick="createNewBlankSheetFromPlanningModal()" style="padding: 0.25rem 0.75rem; font-size: 0.875rem;">
-                        <i class="fas fa-plus"></i> Nouvelle
-                    </button>
-                </h4>
-                <div id="modalBlankSheetsList" style="display: grid; gap: 0.5rem;">
-                    <!-- Les feuilles blanches seront ajoutées ici -->
                 </div>
             </div>
         </div>
@@ -6515,12 +6515,113 @@ async function openPeriodPlanningModal(date, periodNumber, classroomId, isMixedG
         await loadGroupsForClass(classroomValue);
     }
 
+    // Charger la planification existante si elle existe
+    try {
+        const response = await fetch(`/planning/api/slot/${date}/${periodNumber}?classroom_id=${classroomId}`);
+        const data = await response.json();
+
+        if (data.success && data.planning) {
+            // Pré-remplir les champs avec la planification existante
+            document.getElementById('modalPlanningTitle').value = data.planning.title || '';
+            document.getElementById('modalDescription').value = data.planning.description || '';
+        } else {
+            // Vider les champs pour une nouvelle planification
+            document.getElementById('modalPlanningTitle').value = '';
+            document.getElementById('modalDescription').value = '';
+        }
+    } catch (error) {
+        console.warn('Erreur lors du chargement de la planification:', error);
+        // Vider les champs en cas d'erreur
+        document.getElementById('modalPlanningTitle').value = '';
+        document.getElementById('modalDescription').value = '';
+    }
+
     // Charger les feuilles blanches pour cette période
     await loadBlankSheetsForPlanningModal(date, periodNumber, classroomId);
 
     // Afficher le modal
     modal.style.display = 'block';
     overlay.style.display = 'block';
+}
+
+/**
+ * Ferme le modal de planification (surcharge la fonction de planning.js)
+ */
+function closePlanningModal() {
+    const modal = document.getElementById('planningModal');
+    const overlay = document.getElementById('modalOverlay');
+
+    if (modal) {
+        modal.style.display = 'none';
+        modal.classList.remove('show');
+    }
+
+    if (overlay) {
+        overlay.style.display = 'none';
+    }
+
+    // Nettoyer le contexte
+    window.currentPlanningContext = null;
+    currentPlanningCell = null;
+}
+
+/**
+ * Sauvegarde la planification (surcharge la fonction de planning.js pour gérer les périodes)
+ */
+async function savePlanning() {
+    // Si on a un contexte de période (modal ouvert via showPeriodAttendance), utiliser ce contexte
+    if (window.currentPlanningContext) {
+        const { date, periodNumber, classroomId, isMixedGroup } = window.currentPlanningContext;
+        const classroomSelectValue = document.getElementById('modalClassroom').value;
+        const title = document.getElementById('modalPlanningTitle').value;
+        const description = document.getElementById('modalDescription').value;
+        const groupId = document.getElementById('modalGroup') ? document.getElementById('modalGroup').value : null;
+
+        console.log('💾 Sauvegarde planification période:', {date, periodNumber, classroomSelectValue, title});
+
+        try {
+            const response = await fetch('/planning/save', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    date: date,
+                    period: periodNumber,
+                    classroom_id: classroomSelectValue,
+                    title: title,
+                    description: description,
+                    group_id: groupId
+                })
+            });
+
+            const data = await response.json();
+
+            if (data.success) {
+                console.log('✅ Planification sauvegardée avec succès');
+                closePlanningModal();
+                // Recharger la page pour afficher la mise à jour
+                location.reload();
+            } else {
+                alert('Erreur lors de la sauvegarde: ' + (data.error || 'Erreur inconnue'));
+            }
+        } catch (error) {
+            console.error('Erreur lors de la sauvegarde:', error);
+            alert('Erreur de connexion au serveur');
+        }
+        return;
+    }
+
+    // Sinon, utiliser la logique originale de planning.js
+    if (!currentPlanningCell) {
+        console.error('Pas de cellule de planification sélectionnée');
+        return;
+    }
+
+    // Appeler la fonction originale de planning.js si elle existe
+    if (typeof window.originalSavePlanning === 'function') {
+        await window.originalSavePlanning();
+    }
 }
 
 /**

--- a/templates/planning/lesson_view.html
+++ b/templates/planning/lesson_view.html
@@ -2694,7 +2694,10 @@ async function renderBlankSheets() {
     const periodNumber = {{ lesson.period_number if lesson else 0 }};
     const classroomId = {{ lesson_classroom.id if lesson_classroom else 'null' }};
 
+    console.log('📄 renderBlankSheets appelée - date:', lessonDate, 'période:', periodNumber, 'classe:', classroomId);
+
     if (!lessonDate || !periodNumber) {
+        console.warn('⚠️ renderBlankSheets: lessonDate ou periodNumber manquant');
         return;
     }
 
@@ -2702,7 +2705,10 @@ async function renderBlankSheets() {
         const response = await fetch(`/planning/api/blank-sheets/list?date=${lessonDate}&period=${periodNumber}&classroom_id=${classroomId}`);
         const data = await response.json();
 
+        console.log('📋 renderBlankSheets: Données reçues:', data);
+
         if (data.success && data.sheets && data.sheets.length > 0) {
+            console.log('✅ renderBlankSheets: Affichage de', data.sheets.length, 'feuilles blanches');
             const resourcesTree = document.getElementById('resourcesTree');
             if (!resourcesTree) return;
 
@@ -2738,9 +2744,12 @@ async function renderBlankSheets() {
 
             // Insérer avant le contenu actuel (au début de l'arborescence)
             resourcesTree.insertBefore(blankSheetsSection, resourcesTree.firstChild);
+            console.log('✅ renderBlankSheets: Section ajoutée au DOM');
+        } else {
+            console.log('ℹ️ renderBlankSheets: Aucune feuille blanche à afficher');
         }
     } catch (error) {
-        console.error('Erreur lors du chargement des feuilles blanches:', error);
+        console.error('❌ Erreur lors du chargement des feuilles blanches:', error);
     }
 }
 

--- a/templates/planning/lesson_view.html
+++ b/templates/planning/lesson_view.html
@@ -9118,10 +9118,20 @@ function openNewBlankSheet(lessonDate, periodNumber, classroomId) {
         viewerContainer.style.display = 'block';
     }
 
-    if (!cleanPDFViewer) {
+    // Détruire le viewer existant s'il y en a un
+    if (cleanPDFViewer) {
+        console.log('🔄 Destruction du viewer existant...');
         try {
-            cleanPDFViewer = new CleanPDFViewer('unified-pdf-viewer-container', {
-                blankSheetId: null,  // Nouvelle feuille
+            cleanPDFViewer.destroy();
+        } catch (e) {
+            console.warn('Erreur lors de la destruction du viewer:', e);
+        }
+        cleanPDFViewer = null;
+    }
+
+    try {
+        cleanPDFViewer = new CleanPDFViewer('unified-pdf-viewer-container', {
+            blankSheetId: null,  // Nouvelle feuille
                 lessonDate: lessonDate,
                 periodNumber: periodNumber,
                 classroomId: classroomId,
@@ -9141,14 +9151,11 @@ function openNewBlankSheet(lessonDate, periodNumber, classroomId) {
                 }
             });
 
-            console.log('✅ Nouvelle feuille blanche créée');
-        } catch (error) {
-            console.error('❌ Erreur lors de la création du viewer:', error);
-            alert('Erreur lors de la création du viewer: ' + error.message);
-            return;
-        }
-    } else {
-        console.warn('Le viewer est déjà ouvert. Fermez-le d\'abord.');
+        console.log('✅ Nouvelle feuille blanche créée');
+    } catch (error) {
+        console.error('❌ Erreur lors de la création du viewer:', error);
+        alert('Erreur lors de la création du viewer: ' + error.message);
+        return;
     }
 }
 
@@ -9190,9 +9197,19 @@ async function openExistingBlankSheet(sheetId) {
             viewerContainer.style.display = 'block';
         }
 
-        if (!cleanPDFViewer) {
+        // Détruire le viewer existant s'il y en a un
+        if (cleanPDFViewer) {
+            console.log('🔄 Destruction du viewer existant...');
             try {
-                cleanPDFViewer = new CleanPDFViewer('unified-pdf-viewer-container', {
+                cleanPDFViewer.destroy();
+            } catch (e) {
+                console.warn('Erreur lors de la destruction du viewer:', e);
+            }
+            cleanPDFViewer = null;
+        }
+
+        try {
+            cleanPDFViewer = new CleanPDFViewer('unified-pdf-viewer-container', {
                     blankSheetId: sheet.id,
                     lessonDate: sheet.lesson_date,
                     periodNumber: sheet.period_number,
@@ -9213,14 +9230,11 @@ async function openExistingBlankSheet(sheetId) {
                     }
                 });
 
-                console.log('✅ Feuille blanche chargée');
-            } catch (error) {
-                console.error('❌ Erreur lors du chargement du viewer:', error);
-                alert('Erreur lors du chargement du viewer: ' + error.message);
-                return;
-            }
-        } else {
-            console.warn('Le viewer est déjà ouvert. Fermez-le d\'abord.');
+            console.log('✅ Feuille blanche chargée');
+        } catch (error) {
+            console.error('❌ Erreur lors du chargement du viewer:', error);
+            alert('Erreur lors du chargement du viewer: ' + error.message);
+            return;
         }
     } catch (error) {
         console.error('Erreur lors du chargement de la feuille blanche:', error);

--- a/templates/planning/lesson_view.html
+++ b/templates/planning/lesson_view.html
@@ -2,6 +2,8 @@
 
 {% block title %}{% if is_current %}Leçon en cours{% else %}Prochain cours{% endif %} - TeacherPlanner{% endblock %}
 
+<!-- VERSION: 2dfd042-fix-studentsdata-tojson - 2026-01-19T16:35:00Z -->
+
 {% block extra_css %}
 <!-- Cache busting pour forcer le rechargement -->
 <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">

--- a/templates/planning/lesson_view.html
+++ b/templates/planning/lesson_view.html
@@ -1413,6 +1413,9 @@ input, textarea, select {
                     <button class="resource-btn" onclick="refreshResources()" title="Actualiser">
                         <i class="fas fa-sync-alt"></i>
                     </button>
+                    <button class="add-resource-btn" onclick="openBlankPages()" title="Créer des feuilles blanches" style="margin-right: 0.5rem;">
+                        <i class="fas fa-file-medical"></i> Feuilles blanches
+                    </button>
                     <a href="{{ url_for('file_manager.index') }}" class="add-resource-btn" target="_blank">
                         <i class="fas fa-plus"></i> Gestionnaire
                     </a>
@@ -8792,10 +8795,72 @@ function openFileWithUnifiedViewer(filePath, fileName) {
 // closeFileViewer() est défini plus haut dans le fichier (ligne ~5354)
 // Ne pas dupliquer la fonction ici
 
+// Fonction pour ouvrir le viewer avec des pages blanches
+function openBlankPages() {
+    console.log('📄 Ouverture du viewer avec des pages blanches');
+
+    // Afficher la modal
+    const modal = document.getElementById('fileViewerModal');
+    if (!modal) {
+        console.error('Modal fileViewerModal non trouvée');
+        return;
+    }
+
+    modal.style.display = 'block';
+    document.body.style.overflow = 'hidden';
+
+    // Vérifier la disponibilité des données des élèves
+    if (typeof studentsData === 'undefined' || !Array.isArray(studentsData)) {
+        console.warn('studentsData non défini, utilisation d'un tableau vide');
+        studentsData = [];
+    }
+
+    // Afficher le container du viewer
+    const viewerContainer = document.getElementById('unified-pdf-viewer-container');
+    if (viewerContainer) {
+        viewerContainer.style.display = 'block';
+    }
+
+    // Créer un ID spécial pour les pages blanches basé sur la leçon actuelle
+    {% if lesson %}
+    const blankPagesId = 'blank_lesson_{{ lesson.id }}';
+    {% else %}
+    const blankPagesId = 'blank_lesson_new';
+    {% endif %}
+
+    // Créer l'instance du viewer pour pages blanches
+    if (!cleanPDFViewer) {
+        try {
+            cleanPDFViewer = new CleanPDFViewer('unified-pdf-viewer-container', {
+                fileId: blankPagesId, // ID spécial pour sauvegarder les pages blanches
+                pdfUrl: null, // Pas de PDF à charger
+                showSidebar: true,
+                enableAnnotations: true,
+                autoSaveInterval: 5000,
+                studentData: studentsData,
+                onClose: () => {
+                    if (viewerContainer) {
+                        viewerContainer.style.display = 'none';
+                    }
+                    cleanPDFViewer = null;
+                }
+            });
+
+            console.log('✅ Viewer avec pages blanches créé, ID:', blankPagesId);
+        } catch (error) {
+            console.error('❌ Erreur lors de la création du viewer:', error);
+            alert('Erreur lors de la création du viewer: ' + error.message);
+            return;
+        }
+    } else {
+        console.warn('Le viewer est déjà ouvert. Fermez-le d\'abord.');
+    }
+}
+
 // Fonction modifiée pour ouvrir les fichiers (remplace l'ancienne fonction openFile)
 function openFile(filePath, fileName, fileType) {
     console.log('📁 Ouverture du fichier:', fileName, 'Type:', fileType);
-    
+
     if (fileType === 'pdf') {
         // Utiliser le nouveau lecteur unifié pour les PDF
         openFileWithUnifiedViewer(filePath, fileName);

--- a/templates/planning/lesson_view.html
+++ b/templates/planning/lesson_view.html
@@ -2664,7 +2664,7 @@ async function renderBlankSheets() {
     }
 
     try {
-        const response = await fetch(`/api/blank-sheets/list?date=${lessonDate}&period=${periodNumber}&classroom_id=${classroomId}`);
+        const response = await fetch(`/planning/api/blank-sheets/list?date=${lessonDate}&period=${periodNumber}&classroom_id=${classroomId}`);
         const data = await response.json();
 
         if (data.success && data.sheets && data.sheets.length > 0) {
@@ -9031,7 +9031,7 @@ async function showBlankSheetsMenu() {
 
     try {
         // Charger les feuilles blanches existantes
-        const response = await fetch(`/api/blank-sheets/list?date=${lessonDate}&period=${periodNumber}&classroom_id=${classroomId}`);
+        const response = await fetch(`/planning/api/blank-sheets/list?date=${lessonDate}&period=${periodNumber}&classroom_id=${classroomId}`);
         const data = await response.json();
 
         if (!data.success) {
@@ -9160,7 +9160,7 @@ async function openExistingBlankSheet(sheetId) {
 
     try {
         // Charger les données de la feuille
-        const response = await fetch(`/api/blank-sheets/${sheetId}`);
+        const response = await fetch(`/planning/api/blank-sheets/${sheetId}`);
         const data = await response.json();
 
         if (!data.success) {

--- a/templates/planning/lesson_view.html
+++ b/templates/planning/lesson_view.html
@@ -8974,19 +8974,20 @@ function openFileWithUnifiedViewer(filePath, fileName) {
     console.log('🎯 Ouverture avec le lecteur unifié:', fileName);
 
     // Vérifier et obtenir la modal parente d'abord
-    let modal = document.getElementById('fileViewerModal');
-    console.log('🔍 Modal trouvée:', modal);
+    // Utiliser querySelector directement car c'est plus fiable
+    let modal = document.querySelector('.file-viewer-modal');
+    console.log('🔍 Modal trouvée (querySelector):', modal);
+
+    // Fallback sur getElementById si querySelector ne fonctionne pas
+    if (!modal) {
+        modal = document.getElementById('fileViewerModal');
+        console.log('🔍 Modal trouvée (getElementById):', modal);
+    }
 
     if (!modal) {
-        console.warn('⚠️ Modal fileViewerModal non trouvée, tentative de recherche alternative...');
-        // Essayer de trouver la modal par classe
-        modal = document.querySelector('.file-viewer-modal');
-        if (!modal) {
-            console.error('❌ Impossible de trouver la modal, rechargement de la page recommandé');
-            alert('Erreur: La modal de visualisation n\'existe pas.\n\nVeuillez recharger la page (Ctrl/Cmd+R).');
-            return;
-        }
-        console.log('✅ Modal trouvée via sélecteur de classe');
+        console.error('❌ Impossible de trouver la modal avec querySelector et getElementById');
+        alert('Erreur: La modal de visualisation n\'existe pas.\n\nVeuillez recharger la page (Ctrl/Cmd+R).');
+        return;
     }
 
     // Afficher la modal d'abord
@@ -9192,19 +9193,20 @@ function openNewBlankSheet(lessonDate, periodNumber, classroomId) {
     console.log('📄 Création nouvelle feuille blanche');
 
     // Vérifier et obtenir la modal parente d'abord
-    let modal = document.getElementById('fileViewerModal');
-    console.log('🔍 Modal trouvée:', modal);
+    // Utiliser querySelector directement car c'est plus fiable
+    let modal = document.querySelector('.file-viewer-modal');
+    console.log('🔍 Modal trouvée (querySelector):', modal);
+
+    // Fallback sur getElementById si querySelector ne fonctionne pas
+    if (!modal) {
+        modal = document.getElementById('fileViewerModal');
+        console.log('🔍 Modal trouvée (getElementById):', modal);
+    }
 
     if (!modal) {
-        console.warn('⚠️ Modal fileViewerModal non trouvée, tentative de recherche alternative...');
-        // Essayer de trouver la modal par classe
-        modal = document.querySelector('.file-viewer-modal');
-        if (!modal) {
-            console.error('❌ Impossible de trouver la modal, rechargement de la page recommandé');
-            alert('Erreur: La modal de visualisation n\'existe pas.\n\nVeuillez recharger la page (Ctrl/Cmd+R).');
-            return;
-        }
-        console.log('✅ Modal trouvée via sélecteur de classe');
+        console.error('❌ Impossible de trouver la modal avec querySelector et getElementById');
+        alert('Erreur: La modal de visualisation n\'existe pas.\n\nVeuillez recharger la page (Ctrl/Cmd+R).');
+        return;
     }
 
     // Afficher la modal d'abord
@@ -9319,20 +9321,24 @@ async function openExistingBlankSheet(sheetId) {
         const sheet = data.sheet;
         console.log('📋 Données de la feuille chargées:', sheet);
 
+        // Attendre que le DOM soit stable (au cas où un autre script manipule le DOM)
+        await new Promise(resolve => requestAnimationFrame(resolve));
+
         // Vérifier et obtenir la modal parente d'abord
-        let modal = document.getElementById('fileViewerModal');
-        console.log('🔍 Modal trouvée:', modal);
+        // Utiliser querySelector directement car c'est plus fiable
+        let modal = document.querySelector('.file-viewer-modal');
+        console.log('🔍 Modal trouvée (querySelector):', modal);
+
+        // Fallback sur getElementById si querySelector ne fonctionne pas
+        if (!modal) {
+            modal = document.getElementById('fileViewerModal');
+            console.log('🔍 Modal trouvée (getElementById):', modal);
+        }
 
         if (!modal) {
-            console.warn('⚠️ Modal fileViewerModal non trouvée, tentative de recherche alternative...');
-            // Essayer de trouver la modal par classe
-            modal = document.querySelector('.file-viewer-modal');
-            if (!modal) {
-                console.error('❌ Impossible de trouver la modal, rechargement de la page recommandé');
-                alert('Erreur: La modal de visualisation n\'existe pas.\n\nVeuillez recharger la page (Ctrl/Cmd+R).');
-                return;
-            }
-            console.log('✅ Modal trouvée via sélecteur de classe');
+            console.error('❌ Impossible de trouver la modal avec querySelector et getElementById');
+            alert('Erreur: La modal de visualisation n\'existe pas.\n\nVeuillez recharger la page (Ctrl/Cmd+R).');
+            return;
         }
 
         // Afficher la modal d'abord

--- a/templates/planning/lesson_view.html
+++ b/templates/planning/lesson_view.html
@@ -2655,7 +2655,7 @@ function renderResourceTree(files) {
 
 // Fonction pour charger et afficher les feuilles blanches de la leçon
 async function renderBlankSheets() {
-    const lessonDate = '{{ lesson.date.strftime("%Y-%m-%d") if lesson else "" }}';
+    const lessonDate = '{{ lesson_date.strftime("%Y-%m-%d") if lesson_date else "" }}';
     const periodNumber = {{ lesson.period_number if lesson else 0 }};
     const classroomId = {{ lesson_classroom.id if lesson_classroom else 'null' }};
 
@@ -9020,7 +9020,7 @@ function openFileWithUnifiedViewer(filePath, fileName) {
  * Affiche le menu de sélection des feuilles blanches
  */
 async function showBlankSheetsMenu() {
-    const lessonDate = '{{ lesson.date.strftime("%Y-%m-%d") if lesson else "" }}';
+    const lessonDate = '{{ lesson_date.strftime("%Y-%m-%d") if lesson_date else "" }}';
     const periodNumber = {{ lesson.period_number if lesson else 0 }};
     const classroomId = {{ lesson_classroom.id if lesson_classroom else 'null' }};
 

--- a/templates/planning/lesson_view.html
+++ b/templates/planning/lesson_view.html
@@ -1057,6 +1057,41 @@ input, textarea, select {
     gap: 0.5rem;
 }
 
+/* Bouton de suppression des feuilles blanches */
+.btn-delete-blank-sheet {
+    background: none;
+    border: none;
+    color: #dc2626;
+    padding: 0.5rem;
+    cursor: pointer;
+    border-radius: 0.375rem;
+    transition: all 0.2s;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.875rem;
+    opacity: 0.6;
+}
+
+.btn-delete-blank-sheet:hover {
+    background-color: #fee2e2;
+    opacity: 1;
+}
+
+.resource-item.blank-sheet {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    background-color: #fef3c7;
+    border-left: 3px solid #f59e0b;
+}
+
+.resource-item.blank-sheet .resource-info {
+    flex: 1;
+    cursor: pointer;
+}
+
 .resource-item.blank-sheet {
     background-color: #fef3c7;
     border-left: 3px solid #f59e0b;
@@ -2680,11 +2715,11 @@ async function renderBlankSheets() {
                 </h4>
                 <div class="blank-sheets-list">
                     ${data.sheets.map(sheet => `
-                        <div class="resource-item blank-sheet" onclick="openExistingBlankSheet(${sheet.id})">
-                            <div class="resource-icon blank-sheet-icon">
+                        <div class="resource-item blank-sheet">
+                            <div class="resource-icon blank-sheet-icon" onclick="openExistingBlankSheet(${sheet.id})">
                                 <i class="fas fa-file"></i>
                             </div>
-                            <div class="resource-info">
+                            <div class="resource-info" onclick="openExistingBlankSheet(${sheet.id})">
                                 <div class="resource-main">
                                     <div class="resource-name clickable-file">${escapeHtml(sheet.title)}</div>
                                     <div class="resource-meta">
@@ -2693,6 +2728,9 @@ async function renderBlankSheets() {
                                     </div>
                                 </div>
                             </div>
+                            <button class="btn-delete-blank-sheet" onclick="event.stopPropagation(); deleteBlankSheet(${sheet.id})" title="Supprimer la feuille blanche">
+                                <i class="fas fa-trash"></i>
+                            </button>
                         </div>
                     `).join('')}
                 </div>
@@ -9250,6 +9288,38 @@ function formatDateTime(isoString) {
     const date = new Date(isoString);
     const options = { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' };
     return date.toLocaleDateString('fr-FR', options);
+}
+
+/**
+ * Supprime une feuille blanche
+ */
+async function deleteBlankSheet(sheetId) {
+    console.log('🗑️ Suppression feuille blanche:', sheetId);
+
+    // Confirmer la suppression
+    if (!confirm('Êtes-vous sûr de vouloir supprimer cette feuille blanche ? Cette action est irréversible.')) {
+        return;
+    }
+
+    try {
+        const response = await fetch(`/planning/api/blank-sheets/${sheetId}`, {
+            method: 'DELETE',
+            headers: {'Content-Type': 'application/json'}
+        });
+
+        const data = await response.json();
+
+        if (data.success) {
+            console.log('✅ Feuille blanche supprimée');
+            // Recharger la liste des ressources
+            await loadClassResources();
+        } else {
+            alert('Erreur lors de la suppression: ' + (data.message || 'Erreur inconnue'));
+        }
+    } catch (error) {
+        console.error('Erreur lors de la suppression de la feuille blanche:', error);
+        alert('Erreur lors de la suppression de la feuille blanche');
+    }
 }
 
 // Fonction pour ouvrir le viewer avec des pages blanches (LEGACY - gardée pour compatibilité)

--- a/templates/planning/lesson_view.html
+++ b/templates/planning/lesson_view.html
@@ -8686,16 +8686,7 @@ let cleanPDFViewer = null;
 let currentPDFUrl = null;
 
 // Données des étudiants (définies globalement pour le PDF viewer)
-let studentsData = [
-    {% for student in students %}
-    {
-        id: {{ student.id }},
-        first_name: "{{ student.first_name }}",
-        last_name: "{{ student.last_name or '' }}",
-        full_name: "{{ student.full_name }}"
-    }{% if not loop.last %},{% endif %}
-    {% endfor %}
-];
+let studentsData = {{ students | tojson | safe }};
 
 // Fonction pour ouvrir un fichier avec le nouveau lecteur unifié
 function openFileWithUnifiedViewer(filePath, fileName) {

--- a/templates/planning/lesson_view.html
+++ b/templates/planning/lesson_view.html
@@ -8813,7 +8813,7 @@ function openBlankPages() {
 
     // Vérifier la disponibilité des données des élèves
     if (typeof studentsData === 'undefined' || !Array.isArray(studentsData)) {
-        console.warn('studentsData non défini, utilisation d'un tableau vide');
+        console.warn("studentsData non défini, utilisation d'un tableau vide");
         studentsData = [];
     }
 

--- a/templates/planning/lesson_view.html
+++ b/templates/planning/lesson_view.html
@@ -8686,7 +8686,16 @@ let cleanPDFViewer = null;
 let currentPDFUrl = null;
 
 // Données des étudiants (définies globalement pour le PDF viewer)
-let studentsData = {{ students | tojson | safe }};
+let studentsData = [
+    {% for student in students %}
+    {
+        id: {{ student.id }},
+        first_name: {{ student.first_name | tojson }},
+        last_name: {{ (student.last_name or '') | tojson }},
+        full_name: {{ student.full_name | tojson }}
+    }{% if not loop.last %},{% endif %}
+    {% endfor %}
+];
 
 // Fonction pour ouvrir un fichier avec le nouveau lecteur unifié
 function openFileWithUnifiedViewer(filePath, fileName) {

--- a/templates/planning/lesson_view.html
+++ b/templates/planning/lesson_view.html
@@ -9214,40 +9214,48 @@ async function openExistingBlankSheet(sheetId) {
         }
 
         const sheet = data.sheet;
+        console.log('📋 Données de la feuille chargées:', sheet);
 
         const modal = document.getElementById('fileViewerModal');
+        console.log('🔍 Modal trouvée:', modal);
         if (!modal) {
-            console.error('Modal fileViewerModal non trouvée');
+            console.error('❌ Modal fileViewerModal non trouvée dans le DOM');
+            alert('Erreur: La modal de visualisation n\'existe pas');
             return;
         }
 
-        modal.style.display = 'block';
+        modal.style.display = 'flex';
         document.body.style.overflow = 'hidden';
 
         // Vérifier la disponibilité des données des élèves
         if (typeof studentsData === 'undefined' || !Array.isArray(studentsData)) {
             console.warn("studentsData non défini, utilisation d'un tableau vide");
-            studentsData = [];
+            window.studentsData = [];
         }
 
         const viewerContainer = document.getElementById('unified-pdf-viewer-container');
+        console.log('🔍 Container trouvé:', viewerContainer);
         if (viewerContainer) {
             viewerContainer.style.display = 'block';
+        } else {
+            console.error('❌ Container unified-pdf-viewer-container non trouvé');
+            return;
         }
 
         // Détruire le viewer existant s'il y en a un
-        if (cleanPDFViewer) {
+        if (window.cleanPDFViewer) {
             console.log('🔄 Destruction du viewer existant...');
             try {
-                cleanPDFViewer.destroy();
+                window.cleanPDFViewer.destroy();
             } catch (e) {
                 console.warn('Erreur lors de la destruction du viewer:', e);
             }
-            cleanPDFViewer = null;
+            window.cleanPDFViewer = null;
         }
 
         try {
-            cleanPDFViewer = new CleanPDFViewer('unified-pdf-viewer-container', {
+            console.log('🚀 Création du CleanPDFViewer avec blankSheetId:', sheet.id);
+            window.cleanPDFViewer = new CleanPDFViewer('unified-pdf-viewer-container', {
                     blankSheetId: sheet.id,
                     lessonDate: sheet.lesson_date,
                     periodNumber: sheet.period_number,
@@ -9257,12 +9265,15 @@ async function openExistingBlankSheet(sheetId) {
                     showSidebar: true,
                     enableAnnotations: true,
                     autoSaveInterval: 5000,
-                    studentData: studentsData,
+                    studentData: window.studentsData,
                     onClose: () => {
+                        console.log('🔒 Fermeture du viewer');
+                        modal.style.display = 'none';
+                        document.body.style.overflow = '';
                         if (viewerContainer) {
                             viewerContainer.style.display = 'none';
                         }
-                        cleanPDFViewer = null;
+                        window.cleanPDFViewer = null;
                         // Recharger la liste des ressources pour afficher les modifications
                         loadClassResources();
                     }
@@ -9272,11 +9283,13 @@ async function openExistingBlankSheet(sheetId) {
         } catch (error) {
             console.error('❌ Erreur lors du chargement du viewer:', error);
             alert('Erreur lors du chargement du viewer: ' + error.message);
+            modal.style.display = 'none';
+            document.body.style.overflow = '';
             return;
         }
     } catch (error) {
         console.error('Erreur lors du chargement de la feuille blanche:', error);
-        alert('Erreur lors du chargement de la feuille blanche');
+        alert('Erreur lors du chargement de la feuille blanche: ' + error.message);
     }
 }
 

--- a/templates/planning/lesson_view.html
+++ b/templates/planning/lesson_view.html
@@ -9026,12 +9026,9 @@ function openFileWithUnifiedViewer(filePath, fileName) {
     } catch (error) {
         console.warn('Erreur lors de la récupération du plan de classe:', error);
     }
-    
-    // Afficher le container du viewer
-    const viewerContainer = document.getElementById('unified-pdf-viewer-container');
-    if (viewerContainer) {
-        viewerContainer.style.display = 'block';
-    }
+
+    // Le viewerContainer est déjà défini et affiché au début de la fonction (ligne 8977)
+    // Pas besoin de le redéclarer ici
 
     // Créer l'instance du nouveau lecteur clean s'il n'existe pas
     if (!cleanPDFViewer) {

--- a/templates/planning/lesson_view.html
+++ b/templates/planning/lesson_view.html
@@ -8955,15 +8955,26 @@ let studentsData = [
 // Fonction pour ouvrir un fichier avec le nouveau lecteur unifié
 function openFileWithUnifiedViewer(filePath, fileName) {
     console.log('🎯 Ouverture avec le lecteur unifié:', fileName);
-    
-    // Afficher la modal
-    const modal = document.getElementById('fileViewerModal');
-    if (!modal) {
-        console.error('Modal fileViewerModal non trouvée');
+
+    // Afficher directement le container
+    const viewerContainer = document.getElementById('unified-pdf-viewer-container');
+    if (!viewerContainer) {
+        console.error('❌ Container unified-pdf-viewer-container non trouvé');
+        alert('Erreur: Le container de visualisation n\'existe pas');
         return;
     }
-    
-    modal.style.display = 'block';
+
+    viewerContainer.style.display = 'block';
+
+    // Afficher aussi la modal parente si elle existe
+    const modal = document.getElementById('fileViewerModal');
+    if (modal) {
+        console.log('✅ Modal trouvée, affichage');
+        modal.style.display = 'flex';
+    } else {
+        console.warn('⚠️ Modal non trouvée, affichage direct du container');
+    }
+
     document.body.style.overflow = 'hidden';
     
     // Vérifier la disponibilité des données des élèves
@@ -9136,24 +9147,31 @@ function displayBlankSheetsMenu(sheets, lessonDate, periodNumber, classroomId) {
 function openNewBlankSheet(lessonDate, periodNumber, classroomId) {
     console.log('📄 Création nouvelle feuille blanche');
 
-    const modal = document.getElementById('fileViewerModal');
-    if (!modal) {
-        console.error('Modal fileViewerModal non trouvée');
+    // Afficher directement le container
+    const viewerContainer = document.getElementById('unified-pdf-viewer-container');
+    if (!viewerContainer) {
+        console.error('❌ Container unified-pdf-viewer-container non trouvé');
+        alert('Erreur: Le container de visualisation n\'existe pas');
         return;
     }
 
-    modal.style.display = 'block';
+    viewerContainer.style.display = 'block';
+
+    // Afficher aussi la modal parente si elle existe
+    const modal = document.getElementById('fileViewerModal');
+    if (modal) {
+        console.log('✅ Modal trouvée, affichage');
+        modal.style.display = 'flex';
+    } else {
+        console.warn('⚠️ Modal non trouvée, affichage direct du container');
+    }
+
     document.body.style.overflow = 'hidden';
 
     // Vérifier la disponibilité des données des élèves
     if (typeof studentsData === 'undefined' || !Array.isArray(studentsData)) {
         console.warn("studentsData non défini, utilisation d'un tableau vide");
         studentsData = [];
-    }
-
-    const viewerContainer = document.getElementById('unified-pdf-viewer-container');
-    if (viewerContainer) {
-        viewerContainer.style.display = 'block';
     }
 
     // Détruire le viewer existant s'il y en a un
@@ -9180,10 +9198,21 @@ function openNewBlankSheet(lessonDate, periodNumber, classroomId) {
                 autoSaveInterval: 5000,
                 studentData: studentsData,
                 onClose: () => {
-                    if (viewerContainer) {
-                        viewerContainer.style.display = 'none';
+                    // Fermer la modal si elle existe
+                    const modalToClose = document.getElementById('fileViewerModal');
+                    if (modalToClose) {
+                        modalToClose.style.display = 'none';
                     }
+
+                    // Fermer le container
+                    const containerToClose = document.getElementById('unified-pdf-viewer-container');
+                    if (containerToClose) {
+                        containerToClose.style.display = 'none';
+                    }
+
+                    document.body.style.overflow = '';
                     cleanPDFViewer = null;
+
                     // Recharger la liste des ressources pour afficher la nouvelle feuille
                     loadClassResources();
                 }
@@ -9216,30 +9245,32 @@ async function openExistingBlankSheet(sheetId) {
         const sheet = data.sheet;
         console.log('📋 Données de la feuille chargées:', sheet);
 
-        const modal = document.getElementById('fileViewerModal');
-        console.log('🔍 Modal trouvée:', modal);
-        if (!modal) {
-            console.error('❌ Modal fileViewerModal non trouvée dans le DOM');
-            alert('Erreur: La modal de visualisation n\'existe pas');
+        // Afficher directement le container sans vérifier la modal
+        const viewerContainer = document.getElementById('unified-pdf-viewer-container');
+        console.log('🔍 Container trouvé:', viewerContainer);
+        if (!viewerContainer) {
+            console.error('❌ Container unified-pdf-viewer-container non trouvé');
+            alert('Erreur: Le container de visualisation n\'existe pas');
             return;
         }
 
-        modal.style.display = 'flex';
+        viewerContainer.style.display = 'block';
+
+        // Afficher aussi la modal parente si elle existe
+        const modal = document.getElementById('fileViewerModal');
+        if (modal) {
+            console.log('✅ Modal trouvée, affichage');
+            modal.style.display = 'flex';
+        } else {
+            console.warn('⚠️ Modal non trouvée, affichage direct du container');
+        }
+
         document.body.style.overflow = 'hidden';
 
         // Vérifier la disponibilité des données des élèves
         if (typeof studentsData === 'undefined' || !Array.isArray(studentsData)) {
             console.warn("studentsData non défini, utilisation d'un tableau vide");
             window.studentsData = [];
-        }
-
-        const viewerContainer = document.getElementById('unified-pdf-viewer-container');
-        console.log('🔍 Container trouvé:', viewerContainer);
-        if (viewerContainer) {
-            viewerContainer.style.display = 'block';
-        } else {
-            console.error('❌ Container unified-pdf-viewer-container non trouvé');
-            return;
         }
 
         // Détruire le viewer existant s'il y en a un
@@ -9268,12 +9299,22 @@ async function openExistingBlankSheet(sheetId) {
                     studentData: window.studentsData,
                     onClose: () => {
                         console.log('🔒 Fermeture du viewer');
-                        modal.style.display = 'none';
-                        document.body.style.overflow = '';
-                        if (viewerContainer) {
-                            viewerContainer.style.display = 'none';
+
+                        // Fermer la modal si elle existe
+                        const modalToClose = document.getElementById('fileViewerModal');
+                        if (modalToClose) {
+                            modalToClose.style.display = 'none';
                         }
+
+                        // Fermer le container
+                        const containerToClose = document.getElementById('unified-pdf-viewer-container');
+                        if (containerToClose) {
+                            containerToClose.style.display = 'none';
+                        }
+
+                        document.body.style.overflow = '';
                         window.cleanPDFViewer = null;
+
                         // Recharger la liste des ressources pour afficher les modifications
                         loadClassResources();
                     }

--- a/templates/planning/lesson_view.html
+++ b/templates/planning/lesson_view.html
@@ -2760,6 +2760,14 @@ function escapeHtml(text) {
     return div.innerHTML;
 }
 
+// Fonction pour formater une date ISO en format lisible
+function formatDateTime(isoString) {
+    if (!isoString) return '';
+    const date = new Date(isoString);
+    const options = { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' };
+    return date.toLocaleDateString('fr-FR', options);
+}
+
 // Fonction pour naviguer vers un dossier
 async function navigateToFolder(folderPath) {
     currentFolderPath = folderPath;

--- a/templates/planning/lesson_view.html
+++ b/templates/planning/lesson_view.html
@@ -2721,11 +2721,11 @@ async function renderBlankSheets() {
                 </h4>
                 <div class="blank-sheets-list">
                     ${data.sheets.map(sheet => `
-                        <div class="resource-item blank-sheet">
-                            <div class="resource-icon blank-sheet-icon" onclick="openExistingBlankSheet(${sheet.id})">
+                        <div class="resource-item blank-sheet" data-sheet-id="${sheet.id}">
+                            <div class="resource-icon blank-sheet-icon">
                                 <i class="fas fa-file"></i>
                             </div>
-                            <div class="resource-info" onclick="openExistingBlankSheet(${sheet.id})">
+                            <div class="resource-info">
                                 <div class="resource-main">
                                     <div class="resource-name clickable-file">${escapeHtml(sheet.title)}</div>
                                     <div class="resource-meta">
@@ -2734,7 +2734,7 @@ async function renderBlankSheets() {
                                     </div>
                                 </div>
                             </div>
-                            <button class="btn-delete-blank-sheet" onclick="event.stopPropagation(); deleteBlankSheet(${sheet.id})" title="Supprimer la feuille blanche">
+                            <button class="btn-delete-blank-sheet" data-sheet-id="${sheet.id}" title="Supprimer la feuille blanche">
                                 <i class="fas fa-trash"></i>
                             </button>
                         </div>
@@ -2745,6 +2745,36 @@ async function renderBlankSheets() {
             // Insérer avant le contenu actuel (au début de l'arborescence)
             resourcesTree.insertBefore(blankSheetsSection, resourcesTree.firstChild);
             console.log('✅ renderBlankSheets: Section ajoutée au DOM');
+
+            // Attacher les event listeners après l'insertion dans le DOM
+            blankSheetsSection.querySelectorAll('.resource-item.blank-sheet').forEach(item => {
+                const sheetId = parseInt(item.dataset.sheetId);
+                const icon = item.querySelector('.resource-icon');
+                const info = item.querySelector('.resource-info');
+
+                // Click sur l'icône ou les infos pour ouvrir la feuille
+                if (icon) {
+                    icon.addEventListener('click', () => {
+                        console.log('🖱️ Click sur feuille blanche ID:', sheetId);
+                        openExistingBlankSheet(sheetId);
+                    });
+                }
+                if (info) {
+                    info.addEventListener('click', () => {
+                        console.log('🖱️ Click sur feuille blanche ID:', sheetId);
+                        openExistingBlankSheet(sheetId);
+                    });
+                }
+            });
+
+            // Attacher les event listeners pour les boutons de suppression
+            blankSheetsSection.querySelectorAll('.btn-delete-blank-sheet').forEach(btn => {
+                const sheetId = parseInt(btn.dataset.sheetId);
+                btn.addEventListener('click', (event) => {
+                    event.stopPropagation();
+                    deleteBlankSheet(sheetId);
+                });
+            });
         } else {
             console.log('ℹ️ renderBlankSheets: Aucune feuille blanche à afficher');
         }
@@ -9321,23 +9351,41 @@ async function openExistingBlankSheet(sheetId) {
         const sheet = data.sheet;
         console.log('📋 Données de la feuille chargées:', sheet);
 
-        // Attendre que le DOM soit stable (au cas où un autre script manipule le DOM)
-        await new Promise(resolve => requestAnimationFrame(resolve));
+        // Attendre que tous les scripts et événements en cours soient terminés
+        await new Promise(resolve => setTimeout(resolve, 50));
 
         // Vérifier et obtenir la modal parente d'abord
-        // Utiliser querySelector directement car c'est plus fiable
+        // Essayer plusieurs méthodes pour trouver la modal
         let modal = document.querySelector('.file-viewer-modal');
         console.log('🔍 Modal trouvée (querySelector):', modal);
 
-        // Fallback sur getElementById si querySelector ne fonctionne pas
         if (!modal) {
             modal = document.getElementById('fileViewerModal');
             console.log('🔍 Modal trouvée (getElementById):', modal);
         }
 
+        // Si toujours pas trouvée, chercher dans tout le document
         if (!modal) {
-            console.error('❌ Impossible de trouver la modal avec querySelector et getElementById');
-            alert('Erreur: La modal de visualisation n\'existe pas.\n\nVeuillez recharger la page (Ctrl/Cmd+R).');
+            console.warn('⚠️ Modal non trouvée, recherche exhaustive...');
+            const allDivs = document.querySelectorAll('div');
+            for (const div of allDivs) {
+                if (div.id === 'fileViewerModal' || div.classList.contains('file-viewer-modal')) {
+                    modal = div;
+                    console.log('✅ Modal trouvée via recherche exhaustive');
+                    break;
+                }
+            }
+        }
+
+        if (!modal) {
+            console.error('❌ Modal introuvable après recherche exhaustive');
+            console.error('📊 État du DOM:', {
+                body: document.body ? 'existe' : 'null',
+                childElementCount: document.body ? document.body.childElementCount : 0,
+                allModals: document.querySelectorAll('[id*="modal"]').length,
+                allViewers: document.querySelectorAll('[id*="viewer"]').length
+            });
+            alert('Erreur: La modal de visualisation n\'existe pas dans le DOM.\n\nVeuillez recharger la page (Ctrl/Cmd+R).');
             return;
         }
 

--- a/templates/planning/lesson_view.html
+++ b/templates/planning/lesson_view.html
@@ -9195,11 +9195,11 @@ function displayBlankSheetsMenu(sheets, lessonDate, periodNumber, classroomId) {
     menu.innerHTML = `
         <div class="menu-header">
             <h4>Feuilles blanches de la leçon</h4>
-            <button class="close-menu-btn" onclick="this.parentElement.parentElement.remove()">×</button>
+            <button class="close-menu-btn">×</button>
         </div>
         <div class="menu-list">
             ${sheets.map(sheet => `
-                <div class="sheet-item" onclick="openExistingBlankSheet(${sheet.id}); this.parentElement.parentElement.parentElement.remove();">
+                <div class="sheet-item" data-sheet-id="${sheet.id}">
                     <i class="fas fa-file"></i>
                     <div class="sheet-info">
                         <span class="sheet-title">${sheet.title}</span>
@@ -9208,12 +9208,40 @@ function displayBlankSheetsMenu(sheets, lessonDate, periodNumber, classroomId) {
                 </div>
             `).join('')}
         </div>
-        <button class="btn-primary new-sheet-btn" onclick="openNewBlankSheet('${lessonDate}', ${periodNumber}, ${classroomId}); this.parentElement.remove();">
+        <button class="btn-primary new-sheet-btn">
             <i class="fas fa-plus"></i> Nouvelle feuille
         </button>
     `;
 
     document.body.appendChild(menu);
+
+    // Attacher les event listeners après l'ajout au DOM
+    const closeBtn = menu.querySelector('.close-menu-btn');
+    if (closeBtn) {
+        closeBtn.addEventListener('click', () => {
+            menu.remove();
+        });
+    }
+
+    // Event listeners pour les feuilles existantes
+    menu.querySelectorAll('.sheet-item').forEach(item => {
+        const sheetId = parseInt(item.dataset.sheetId);
+        item.addEventListener('click', () => {
+            console.log('🖱️ Click menu: Ouverture feuille', sheetId);
+            menu.remove(); // Fermer le menu d'abord
+            openExistingBlankSheet(sheetId); // Puis ouvrir la feuille
+        });
+    });
+
+    // Event listener pour le bouton nouvelle feuille
+    const newSheetBtn = menu.querySelector('.new-sheet-btn');
+    if (newSheetBtn) {
+        newSheetBtn.addEventListener('click', () => {
+            console.log('🖱️ Click menu: Nouvelle feuille');
+            menu.remove(); // Fermer le menu d'abord
+            openNewBlankSheet(lessonDate, periodNumber, classroomId); // Puis créer nouvelle feuille
+        });
+    }
 }
 
 /**

--- a/templates/planning/lesson_view.html
+++ b/templates/planning/lesson_view.html
@@ -9161,25 +9161,55 @@ function displayBlankSheetsMenu(sheets, lessonDate, periodNumber, classroomId) {
 function openNewBlankSheet(lessonDate, periodNumber, classroomId) {
     console.log('📄 Création nouvelle feuille blanche');
 
-    // Afficher directement le container
-    const viewerContainer = document.getElementById('unified-pdf-viewer-container');
+    // Vérifier et obtenir la modal parente d'abord
+    let modal = document.getElementById('fileViewerModal');
+    console.log('🔍 Modal trouvée:', modal);
+
+    if (!modal) {
+        console.warn('⚠️ Modal fileViewerModal non trouvée, tentative de recherche alternative...');
+        // Essayer de trouver la modal par classe
+        modal = document.querySelector('.file-viewer-modal');
+        if (!modal) {
+            console.error('❌ Impossible de trouver la modal, rechargement de la page recommandé');
+            alert('Erreur: La modal de visualisation n\'existe pas.\n\nVeuillez recharger la page (Ctrl/Cmd+R).');
+            return;
+        }
+        console.log('✅ Modal trouvée via sélecteur de classe');
+    }
+
+    // Afficher la modal d'abord
+    modal.style.display = 'flex';
+
+    // Maintenant chercher le container à l'intérieur de la modal
+    let viewerContainer = document.getElementById('unified-pdf-viewer-container');
+    console.log('🔍 Container trouvé:', viewerContainer);
+
     if (!viewerContainer) {
-        console.error('❌ Container unified-pdf-viewer-container non trouvé');
-        alert('Erreur: Le container de visualisation n\'existe pas');
-        return;
+        console.warn('⚠️ Container non trouvé par ID, recherche dans la modal...');
+        // Chercher le container dans la modal
+        viewerContainer = modal.querySelector('#unified-pdf-viewer-container');
+        if (!viewerContainer) {
+            console.error('❌ Container toujours introuvable, tentative de recréation...');
+            // Essayer de recréer le container
+            const wrapper = modal.querySelector('.unified-pdf-viewer-wrapper');
+            if (wrapper) {
+                console.log('🔧 Wrapper trouvé, recréation du container...');
+                viewerContainer = document.createElement('div');
+                viewerContainer.id = 'unified-pdf-viewer-container';
+                wrapper.appendChild(viewerContainer);
+                console.log('✅ Container recréé avec succès');
+            } else {
+                console.error('❌ Wrapper introuvable, impossible de recréer le container');
+                alert('Erreur: Le container de visualisation n\'existe pas.\n\nVeuillez recharger la page (Ctrl/Cmd+R).');
+                modal.style.display = 'none';
+                return;
+            }
+        } else {
+            console.log('✅ Container trouvé dans la modal via querySelector');
+        }
     }
 
     viewerContainer.style.display = 'block';
-
-    // Afficher aussi la modal parente si elle existe
-    const modal = document.getElementById('fileViewerModal');
-    if (modal) {
-        console.log('✅ Modal trouvée, affichage');
-        modal.style.display = 'flex';
-    } else {
-        console.warn('⚠️ Modal non trouvée, affichage direct du container');
-    }
-
     document.body.style.overflow = 'hidden';
 
     // Vérifier la disponibilité des données des élèves
@@ -9259,26 +9289,55 @@ async function openExistingBlankSheet(sheetId) {
         const sheet = data.sheet;
         console.log('📋 Données de la feuille chargées:', sheet);
 
-        // Afficher directement le container sans vérifier la modal
-        const viewerContainer = document.getElementById('unified-pdf-viewer-container');
+        // Vérifier et obtenir la modal parente d'abord
+        let modal = document.getElementById('fileViewerModal');
+        console.log('🔍 Modal trouvée:', modal);
+
+        if (!modal) {
+            console.warn('⚠️ Modal fileViewerModal non trouvée, tentative de recherche alternative...');
+            // Essayer de trouver la modal par classe
+            modal = document.querySelector('.file-viewer-modal');
+            if (!modal) {
+                console.error('❌ Impossible de trouver la modal, rechargement de la page recommandé');
+                alert('Erreur: La modal de visualisation n\'existe pas.\n\nVeuillez recharger la page (Ctrl/Cmd+R).');
+                return;
+            }
+            console.log('✅ Modal trouvée via sélecteur de classe');
+        }
+
+        // Afficher la modal d'abord
+        modal.style.display = 'flex';
+
+        // Maintenant chercher le container à l'intérieur de la modal
+        let viewerContainer = document.getElementById('unified-pdf-viewer-container');
         console.log('🔍 Container trouvé:', viewerContainer);
+
         if (!viewerContainer) {
-            console.error('❌ Container unified-pdf-viewer-container non trouvé');
-            alert('Erreur: Le container de visualisation n\'existe pas');
-            return;
+            console.warn('⚠️ Container non trouvé par ID, recherche dans la modal...');
+            // Chercher le container dans la modal
+            viewerContainer = modal.querySelector('#unified-pdf-viewer-container');
+            if (!viewerContainer) {
+                console.error('❌ Container toujours introuvable, tentative de recréation...');
+                // Essayer de recréer le container
+                const wrapper = modal.querySelector('.unified-pdf-viewer-wrapper');
+                if (wrapper) {
+                    console.log('🔧 Wrapper trouvé, recréation du container...');
+                    viewerContainer = document.createElement('div');
+                    viewerContainer.id = 'unified-pdf-viewer-container';
+                    wrapper.appendChild(viewerContainer);
+                    console.log('✅ Container recréé avec succès');
+                } else {
+                    console.error('❌ Wrapper introuvable, impossible de recréer le container');
+                    alert('Erreur: Le container de visualisation n\'existe pas.\n\nVeuillez recharger la page (Ctrl/Cmd+R).');
+                    modal.style.display = 'none';
+                    return;
+                }
+            } else {
+                console.log('✅ Container trouvé dans la modal via querySelector');
+            }
         }
 
         viewerContainer.style.display = 'block';
-
-        // Afficher aussi la modal parente si elle existe
-        const modal = document.getElementById('fileViewerModal');
-        if (modal) {
-            console.log('✅ Modal trouvée, affichage');
-            modal.style.display = 'flex';
-        } else {
-            console.warn('⚠️ Modal non trouvée, affichage direct du container');
-        }
-
         document.body.style.overflow = 'hidden';
 
         // Vérifier la disponibilité des données des élèves

--- a/templates/planning/lesson_view.html
+++ b/templates/planning/lesson_view.html
@@ -921,6 +921,150 @@ input, textarea, select {
         font-size: 0.875rem;
     }
 }
+
+/* ============================================================================
+   MENU DES FEUILLES BLANCHES
+   ============================================================================ */
+
+.blank-sheets-menu {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: white;
+    padding: 1.5rem;
+    border-radius: 0.5rem;
+    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
+    z-index: 10000;
+    min-width: 400px;
+    max-width: 500px;
+}
+
+.blank-sheets-menu .menu-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 2px solid #e5e7eb;
+}
+
+.blank-sheets-menu .menu-header h4 {
+    margin: 0;
+    font-size: 1.125rem;
+    color: #1f2937;
+}
+
+.blank-sheets-menu .close-menu-btn {
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    color: #9ca3af;
+    cursor: pointer;
+    padding: 0;
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 0.25rem;
+    transition: all 0.2s;
+}
+
+.blank-sheets-menu .close-menu-btn:hover {
+    background-color: #f3f4f6;
+    color: #1f2937;
+}
+
+.blank-sheets-menu .menu-list {
+    max-height: 400px;
+    overflow-y: auto;
+    margin-bottom: 1rem;
+}
+
+.blank-sheets-menu .sheet-item {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem;
+    border-radius: 0.375rem;
+    cursor: pointer;
+    transition: background-color 0.2s;
+    border: 1px solid transparent;
+}
+
+.blank-sheets-menu .sheet-item:hover {
+    background-color: #fef3c7;
+    border-color: #fbbf24;
+}
+
+.blank-sheets-menu .sheet-item i {
+    font-size: 1.25rem;
+    color: #f59e0b;
+}
+
+.blank-sheets-menu .sheet-info {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.blank-sheets-menu .sheet-title {
+    font-weight: 500;
+    color: #1f2937;
+}
+
+.blank-sheets-menu .sheet-date {
+    font-size: 0.75rem;
+    color: #6b7280;
+}
+
+.blank-sheets-menu .new-sheet-btn {
+    width: 100%;
+    padding: 0.75rem;
+    background-color: #3b82f6;
+    color: white;
+    border: none;
+    border-radius: 0.375rem;
+    font-weight: 500;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    transition: background-color 0.2s;
+}
+
+.blank-sheets-menu .new-sheet-btn:hover {
+    background-color: #2563eb;
+}
+
+/* Section feuilles blanches dans la liste des ressources */
+.blank-sheets-section {
+    margin-bottom: 1.5rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+.section-subtitle {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: #6b7280;
+    margin-bottom: 0.5rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.resource-item.blank-sheet {
+    background-color: #fef3c7;
+    border-left: 3px solid #f59e0b;
+}
+
+.resource-item.blank-sheet:hover {
+    background-color: #fde68a;
+}
 </style>
 {% endblock %}
 
@@ -1415,7 +1559,7 @@ input, textarea, select {
                     <button class="resource-btn" onclick="refreshResources()" title="Actualiser">
                         <i class="fas fa-sync-alt"></i>
                     </button>
-                    <button class="add-resource-btn" onclick="openBlankPages()" title="Créer des feuilles blanches" style="margin-right: 0.5rem;">
+                    <button class="add-resource-btn" onclick="showBlankSheetsMenu()" title="Créer ou ouvrir des feuilles blanches" style="margin-right: 0.5rem;">
                         <i class="fas fa-file-medical"></i> Feuilles blanches
                     </button>
                     <a href="{{ url_for('file_manager.index') }}" class="add-resource-btn" target="_blank">
@@ -2254,7 +2398,7 @@ async function loadClassResources() {
         
         if (result.success) {
             classResources = result.files || [];
-            renderResources(result.pinned_files || [], classResources);
+            await renderResources(result.pinned_files || [], classResources);
         } else {
             showNoResources();
         }
@@ -2288,15 +2432,15 @@ function showNoResources() {
 }
 
 // Fonction pour rendre les ressources
-function renderResources(pinnedFiles, allFiles) {
+async function renderResources(pinnedFiles, allFiles) {
     const pinnedElement = document.getElementById('pinnedResources');
     const navigationElement = document.getElementById('folderNavigation');
     const treeElement = document.getElementById('resourcesTree');
     const noResourcesElement = document.getElementById('noResources');
-    
+
     // Masquer l'état vide
     if (noResourcesElement) noResourcesElement.style.display = 'none';
-    
+
     // Afficher les ressources épinglées
     if (pinnedFiles && pinnedFiles.length > 0) {
         renderPinnedResources(pinnedFiles);
@@ -2304,7 +2448,7 @@ function renderResources(pinnedFiles, allFiles) {
     } else {
         if (pinnedElement) pinnedElement.style.display = 'none';
     }
-    
+
     // À la racine, passer tous les fichiers à renderResourceTree pour qu'elle puisse extraire les dossiers
     // Dans un dossier spécifique, filtrer seulement les fichiers de ce dossier
     let filesToDisplay;
@@ -2315,11 +2459,16 @@ function renderResources(pinnedFiles, allFiles) {
         // Dans un dossier : filtrer
         filesToDisplay = filterFilesByFolder(allFiles, currentFolderPath);
     }
-    
+
     // Afficher la navigation
     renderBreadcrumb();
     if (navigationElement) navigationElement.style.display = 'block';
-    
+
+    // Afficher les feuilles blanches (uniquement à la racine)
+    if (!currentFolderPath) {
+        await renderBlankSheets();
+    }
+
     // Afficher l'arborescence
     renderResourceTree(filesToDisplay);
     if (treeElement) treeElement.style.display = 'block';
@@ -2504,10 +2653,70 @@ function renderResourceTree(files) {
     treeElement.innerHTML = html || '<p style="text-align: center; color: #6B7280; padding: 2rem;">Aucun fichier dans ce dossier</p>';
 }
 
+// Fonction pour charger et afficher les feuilles blanches de la leçon
+async function renderBlankSheets() {
+    const lessonDate = '{{ lesson.date.strftime("%Y-%m-%d") if lesson else "" }}';
+    const periodNumber = {{ lesson.period_number if lesson else 0 }};
+    const classroomId = {{ lesson_classroom.id if lesson_classroom else 'null' }};
+
+    if (!lessonDate || !periodNumber) {
+        return;
+    }
+
+    try {
+        const response = await fetch(`/api/blank-sheets/list?date=${lessonDate}&period=${periodNumber}&classroom_id=${classroomId}`);
+        const data = await response.json();
+
+        if (data.success && data.sheets && data.sheets.length > 0) {
+            const resourcesTree = document.getElementById('resourcesTree');
+            if (!resourcesTree) return;
+
+            // Créer la section des feuilles blanches
+            const blankSheetsSection = document.createElement('div');
+            blankSheetsSection.className = 'blank-sheets-section';
+            blankSheetsSection.innerHTML = `
+                <h4 class="section-subtitle">
+                    <i class="fas fa-file"></i> Feuilles blanches
+                </h4>
+                <div class="blank-sheets-list">
+                    ${data.sheets.map(sheet => `
+                        <div class="resource-item blank-sheet" onclick="openExistingBlankSheet(${sheet.id})">
+                            <div class="resource-icon blank-sheet-icon">
+                                <i class="fas fa-file"></i>
+                            </div>
+                            <div class="resource-info">
+                                <div class="resource-main">
+                                    <div class="resource-name clickable-file">${escapeHtml(sheet.title)}</div>
+                                    <div class="resource-meta">
+                                        <span>${formatDateTime(sheet.created_at)}</span>
+                                        <span class="annotatable-badge">✏️ Annotable</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    `).join('')}
+                </div>
+            `;
+
+            // Insérer avant le contenu actuel (au début de l'arborescence)
+            resourcesTree.insertBefore(blankSheetsSection, resourcesTree.firstChild);
+        }
+    } catch (error) {
+        console.error('Erreur lors du chargement des feuilles blanches:', error);
+    }
+}
+
+// Fonction utilitaire pour échapper le HTML
+function escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+}
+
 // Fonction pour naviguer vers un dossier
-function navigateToFolder(folderPath) {
+async function navigateToFolder(folderPath) {
     currentFolderPath = folderPath;
-    
+
     // Utiliser la même logique que dans renderResources
     let filesToDisplay;
     if (!currentFolderPath) {
@@ -2517,8 +2726,14 @@ function navigateToFolder(folderPath) {
         // Dans un dossier : filtrer
         filesToDisplay = filterFilesByFolder(classResources, currentFolderPath);
     }
-    
+
     renderBreadcrumb();
+
+    // Afficher les feuilles blanches seulement à la racine
+    if (!currentFolderPath) {
+        await renderBlankSheets();
+    }
+
     renderResourceTree(filesToDisplay);
 }
 
@@ -8797,7 +9012,233 @@ function openFileWithUnifiedViewer(filePath, fileName) {
 // closeFileViewer() est défini plus haut dans le fichier (ligne ~5354)
 // Ne pas dupliquer la fonction ici
 
-// Fonction pour ouvrir le viewer avec des pages blanches
+// ============================================================================
+// GESTION DES FEUILLES BLANCHES
+// ============================================================================
+
+/**
+ * Affiche le menu de sélection des feuilles blanches
+ */
+async function showBlankSheetsMenu() {
+    const lessonDate = '{{ lesson.date.strftime("%Y-%m-%d") if lesson else "" }}';
+    const periodNumber = {{ lesson.period_number if lesson else 0 }};
+    const classroomId = {{ lesson_classroom.id if lesson_classroom else 'null' }};
+
+    if (!lessonDate || !periodNumber) {
+        alert('Informations de leçon manquantes');
+        return;
+    }
+
+    try {
+        // Charger les feuilles blanches existantes
+        const response = await fetch(`/api/blank-sheets/list?date=${lessonDate}&period=${periodNumber}&classroom_id=${classroomId}`);
+        const data = await response.json();
+
+        if (!data.success) {
+            console.error('Erreur chargement feuilles blanches:', data.error);
+            // Créer directement une nouvelle feuille en cas d'erreur
+            openNewBlankSheet(lessonDate, periodNumber, classroomId);
+            return;
+        }
+
+        if (data.sheets.length === 0) {
+            // Aucune feuille existante, créer directement
+            openNewBlankSheet(lessonDate, periodNumber, classroomId);
+        } else {
+            // Afficher menu de sélection
+            displayBlankSheetsMenu(data.sheets, lessonDate, periodNumber, classroomId);
+        }
+    } catch (error) {
+        console.error('Erreur lors du chargement des feuilles blanches:', error);
+        // Créer directement une nouvelle feuille en cas d'erreur
+        openNewBlankSheet(lessonDate, periodNumber, classroomId);
+    }
+}
+
+/**
+ * Affiche un menu pour sélectionner ou créer une feuille blanche
+ */
+function displayBlankSheetsMenu(sheets, lessonDate, periodNumber, classroomId) {
+    // Supprimer menu existant si présent
+    const existingMenu = document.querySelector('.blank-sheets-menu');
+    if (existingMenu) {
+        existingMenu.remove();
+    }
+
+    // Créer le menu
+    const menu = document.createElement('div');
+    menu.className = 'blank-sheets-menu';
+    menu.innerHTML = `
+        <div class="menu-header">
+            <h4>Feuilles blanches de la leçon</h4>
+            <button class="close-menu-btn" onclick="this.parentElement.parentElement.remove()">×</button>
+        </div>
+        <div class="menu-list">
+            ${sheets.map(sheet => `
+                <div class="sheet-item" onclick="openExistingBlankSheet(${sheet.id}); this.parentElement.parentElement.parentElement.remove();">
+                    <i class="fas fa-file"></i>
+                    <div class="sheet-info">
+                        <span class="sheet-title">${sheet.title}</span>
+                        <small class="sheet-date">${formatDateTime(sheet.created_at)}</small>
+                    </div>
+                </div>
+            `).join('')}
+        </div>
+        <button class="btn-primary new-sheet-btn" onclick="openNewBlankSheet('${lessonDate}', ${periodNumber}, ${classroomId}); this.parentElement.remove();">
+            <i class="fas fa-plus"></i> Nouvelle feuille
+        </button>
+    `;
+
+    document.body.appendChild(menu);
+}
+
+/**
+ * Ouvre le viewer pour créer une nouvelle feuille blanche
+ */
+function openNewBlankSheet(lessonDate, periodNumber, classroomId) {
+    console.log('📄 Création nouvelle feuille blanche');
+
+    const modal = document.getElementById('fileViewerModal');
+    if (!modal) {
+        console.error('Modal fileViewerModal non trouvée');
+        return;
+    }
+
+    modal.style.display = 'block';
+    document.body.style.overflow = 'hidden';
+
+    // Vérifier la disponibilité des données des élèves
+    if (typeof studentsData === 'undefined' || !Array.isArray(studentsData)) {
+        console.warn("studentsData non défini, utilisation d'un tableau vide");
+        studentsData = [];
+    }
+
+    const viewerContainer = document.getElementById('unified-pdf-viewer-container');
+    if (viewerContainer) {
+        viewerContainer.style.display = 'block';
+    }
+
+    if (!cleanPDFViewer) {
+        try {
+            cleanPDFViewer = new CleanPDFViewer('unified-pdf-viewer-container', {
+                blankSheetId: null,  // Nouvelle feuille
+                lessonDate: lessonDate,
+                periodNumber: periodNumber,
+                classroomId: classroomId,
+                title: 'Feuille blanche',
+                pdfUrl: null,
+                showSidebar: true,
+                enableAnnotations: true,
+                autoSaveInterval: 5000,
+                studentData: studentsData,
+                onClose: () => {
+                    if (viewerContainer) {
+                        viewerContainer.style.display = 'none';
+                    }
+                    cleanPDFViewer = null;
+                    // Recharger la liste des ressources pour afficher la nouvelle feuille
+                    loadClassResources();
+                }
+            });
+
+            console.log('✅ Nouvelle feuille blanche créée');
+        } catch (error) {
+            console.error('❌ Erreur lors de la création du viewer:', error);
+            alert('Erreur lors de la création du viewer: ' + error.message);
+            return;
+        }
+    } else {
+        console.warn('Le viewer est déjà ouvert. Fermez-le d\'abord.');
+    }
+}
+
+/**
+ * Ouvre une feuille blanche existante
+ */
+async function openExistingBlankSheet(sheetId) {
+    console.log('📄 Ouverture feuille blanche:', sheetId);
+
+    try {
+        // Charger les données de la feuille
+        const response = await fetch(`/api/blank-sheets/${sheetId}`);
+        const data = await response.json();
+
+        if (!data.success) {
+            alert('Erreur lors du chargement de la feuille: ' + (data.message || 'Erreur inconnue'));
+            return;
+        }
+
+        const sheet = data.sheet;
+
+        const modal = document.getElementById('fileViewerModal');
+        if (!modal) {
+            console.error('Modal fileViewerModal non trouvée');
+            return;
+        }
+
+        modal.style.display = 'block';
+        document.body.style.overflow = 'hidden';
+
+        // Vérifier la disponibilité des données des élèves
+        if (typeof studentsData === 'undefined' || !Array.isArray(studentsData)) {
+            console.warn("studentsData non défini, utilisation d'un tableau vide");
+            studentsData = [];
+        }
+
+        const viewerContainer = document.getElementById('unified-pdf-viewer-container');
+        if (viewerContainer) {
+            viewerContainer.style.display = 'block';
+        }
+
+        if (!cleanPDFViewer) {
+            try {
+                cleanPDFViewer = new CleanPDFViewer('unified-pdf-viewer-container', {
+                    blankSheetId: sheet.id,
+                    lessonDate: sheet.lesson_date,
+                    periodNumber: sheet.period_number,
+                    classroomId: sheet.classroom_id,
+                    title: sheet.title,
+                    pdfUrl: null,
+                    showSidebar: true,
+                    enableAnnotations: true,
+                    autoSaveInterval: 5000,
+                    studentData: studentsData,
+                    onClose: () => {
+                        if (viewerContainer) {
+                            viewerContainer.style.display = 'none';
+                        }
+                        cleanPDFViewer = null;
+                        // Recharger la liste des ressources pour afficher les modifications
+                        loadClassResources();
+                    }
+                });
+
+                console.log('✅ Feuille blanche chargée');
+            } catch (error) {
+                console.error('❌ Erreur lors du chargement du viewer:', error);
+                alert('Erreur lors du chargement du viewer: ' + error.message);
+                return;
+            }
+        } else {
+            console.warn('Le viewer est déjà ouvert. Fermez-le d\'abord.');
+        }
+    } catch (error) {
+        console.error('Erreur lors du chargement de la feuille blanche:', error);
+        alert('Erreur lors du chargement de la feuille blanche');
+    }
+}
+
+/**
+ * Formate une date ISO en format lisible
+ */
+function formatDateTime(isoString) {
+    if (!isoString) return '';
+    const date = new Date(isoString);
+    const options = { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' };
+    return date.toLocaleDateString('fr-FR', options);
+}
+
+// Fonction pour ouvrir le viewer avec des pages blanches (LEGACY - gardée pour compatibilité)
 function openBlankPages() {
     console.log('📄 Ouverture du viewer avec des pages blanches');
 

--- a/templates/planning/lesson_view.html
+++ b/templates/planning/lesson_view.html
@@ -8973,25 +8973,55 @@ let studentsData = [
 function openFileWithUnifiedViewer(filePath, fileName) {
     console.log('🎯 Ouverture avec le lecteur unifié:', fileName);
 
-    // Afficher directement le container
-    const viewerContainer = document.getElementById('unified-pdf-viewer-container');
+    // Vérifier et obtenir la modal parente d'abord
+    let modal = document.getElementById('fileViewerModal');
+    console.log('🔍 Modal trouvée:', modal);
+
+    if (!modal) {
+        console.warn('⚠️ Modal fileViewerModal non trouvée, tentative de recherche alternative...');
+        // Essayer de trouver la modal par classe
+        modal = document.querySelector('.file-viewer-modal');
+        if (!modal) {
+            console.error('❌ Impossible de trouver la modal, rechargement de la page recommandé');
+            alert('Erreur: La modal de visualisation n\'existe pas.\n\nVeuillez recharger la page (Ctrl/Cmd+R).');
+            return;
+        }
+        console.log('✅ Modal trouvée via sélecteur de classe');
+    }
+
+    // Afficher la modal d'abord
+    modal.style.display = 'flex';
+
+    // Maintenant chercher le container à l'intérieur de la modal
+    let viewerContainer = document.getElementById('unified-pdf-viewer-container');
+    console.log('🔍 Container trouvé:', viewerContainer);
+
     if (!viewerContainer) {
-        console.error('❌ Container unified-pdf-viewer-container non trouvé');
-        alert('Erreur: Le container de visualisation n\'existe pas');
-        return;
+        console.warn('⚠️ Container non trouvé par ID, recherche dans la modal...');
+        // Chercher le container dans la modal
+        viewerContainer = modal.querySelector('#unified-pdf-viewer-container');
+        if (!viewerContainer) {
+            console.error('❌ Container toujours introuvable, tentative de recréation...');
+            // Essayer de recréer le container
+            const wrapper = modal.querySelector('.unified-pdf-viewer-wrapper');
+            if (wrapper) {
+                console.log('🔧 Wrapper trouvé, recréation du container...');
+                viewerContainer = document.createElement('div');
+                viewerContainer.id = 'unified-pdf-viewer-container';
+                wrapper.appendChild(viewerContainer);
+                console.log('✅ Container recréé avec succès');
+            } else {
+                console.error('❌ Wrapper introuvable, impossible de recréer le container');
+                alert('Erreur: Le container de visualisation n\'existe pas.\n\nVeuillez recharger la page (Ctrl/Cmd+R).');
+                modal.style.display = 'none';
+                return;
+            }
+        } else {
+            console.log('✅ Container trouvé dans la modal via querySelector');
+        }
     }
 
     viewerContainer.style.display = 'block';
-
-    // Afficher aussi la modal parente si elle existe
-    const modal = document.getElementById('fileViewerModal');
-    if (modal) {
-        console.log('✅ Modal trouvée, affichage');
-        modal.style.display = 'flex';
-    } else {
-        console.warn('⚠️ Modal non trouvée, affichage direct du container');
-    }
-
     document.body.style.overflow = 'hidden';
     
     // Vérifier la disponibilité des données des élèves


### PR DESCRIPTION
Problème: Après désactivation puis réactivation de l'équerre sur /calendar,
l'outil ne répondait plus (impossible de tourner ou déplacer l'équerre).

Cause: Les gestionnaires pointer events étaient retirés dans hideSetSquare()
mais pas réattachés dans showSetSquare() lors de la réactivation
(seulement attachés lors de la création initiale).

Solution: Ne plus retirer les gestionnaires pointer dans hideSetSquare().
Ils vérifient déjà this.setSquareActive et sont inactifs quand l'équerre
est cachée, évitant ainsi le problème de réattachement.