### PR TITLE
feat: Add native PencilKit iOS app for Apple Pencil support

### DIFF
--- a/profcalendar-app/ios/ProfCalendarViewer/Sources/App/ContentView.swift
+++ b/profcalendar-app/ios/ProfCalendarViewer/Sources/App/ContentView.swift
@@ -1,0 +1,35 @@
+//
+//  ContentView.swift
+//  ProfCalendarViewer
+//
+//  Vue principale: WKWebView + PencilKit overlay
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    @StateObject private var drawingCoordinator = DrawingCoordinator()
+    
+    var body: some View {
+        ZStack {
+            // WebView en arriere-plan
+            WebViewContainer(coordinator: drawingCoordinator)
+                .edgesIgnoringSafeArea(.all)
+            
+            // PencilKit overlay (transparent, au-dessus)
+            if drawingCoordinator.isPencilKitActive {
+                PencilKitOverlay(coordinator: drawingCoordinator)
+                    .frame(
+                        width: drawingCoordinator.pageRect.width,
+                        height: drawingCoordinator.pageRect.height
+                    )
+                    .position(
+                        x: drawingCoordinator.pageRect.midX,
+                        y: drawingCoordinator.pageRect.midY
+                    )
+                    .allowsHitTesting(true)
+            }
+        }
+        .statusBar(hidden: true)
+    }
+}

--- a/profcalendar-app/ios/ProfCalendarViewer/Sources/App/ProfCalendarApp.swift
+++ b/profcalendar-app/ios/ProfCalendarViewer/Sources/App/ProfCalendarApp.swift
@@ -1,0 +1,19 @@
+//
+//  ProfCalendarApp.swift
+//  ProfCalendarViewer
+//
+//  Application wrapper qui charge ProfCalendar dans une WKWebView
+//  avec PencilKit overlay pour le dessin natif sur iPad.
+//
+
+import SwiftUI
+
+@main
+struct ProfCalendarApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .edgesIgnoringSafeArea(.all)
+        }
+    }
+}

--- a/profcalendar-app/ios/ProfCalendarViewer/Sources/Drawing/DrawingCoordinator.swift
+++ b/profcalendar-app/ios/ProfCalendarViewer/Sources/Drawing/DrawingCoordinator.swift
@@ -1,0 +1,117 @@
+//
+//  DrawingCoordinator.swift
+//  ProfCalendarViewer
+//
+//  Coordinateur central qui gere l'etat du dessin PencilKit
+//  et la communication entre la WebView et le canvas natif.
+//
+
+import SwiftUI
+import PencilKit
+import WebKit
+import Combine
+
+class DrawingCoordinator: ObservableObject {
+    // Etat PencilKit
+    @Published var isPencilKitActive = false
+    @Published var pageRect = CGRect.zero
+    
+    // Config dessin courante
+    var currentToolName: String = "pen"
+    var currentColorHex: String = "#000000"
+    var currentSize: Double = 2.0
+    var currentOpacity: Double = 1.0
+    var currentScale: Double = 1.0
+    var currentPageId: String = "page-1"
+    
+    // References UI
+    weak var webView: WKWebView?
+    weak var canvasView: PKCanvasView?
+    
+    // Outil PencilKit courant
+    var currentPKTool: PKTool {
+        let color = UIColor(hex: currentColorHex)?.withAlphaComponent(currentOpacity) ?? .black
+        
+        switch currentToolName {
+        case "highlighter":
+            return PKInkingTool(.marker, color: color, width: CGFloat(currentSize * currentScale * 3))
+        default: // pen
+            return PKInkingTool(.pen, color: color, width: CGFloat(currentSize * currentScale))
+        }
+    }
+    
+    // MARK: - Activation / Desactivation
+    
+    func activatePencilKit(
+        tool: String,
+        color: String,
+        size: Double,
+        opacity: Double,
+        pageRect: CGRect,
+        scale: Double,
+        pageId: String
+    ) {
+        self.currentToolName = tool
+        self.currentColorHex = color
+        self.currentSize = size
+        self.currentOpacity = opacity
+        self.pageRect = pageRect
+        self.currentScale = scale
+        self.currentPageId = pageId
+        self.isPencilKitActive = true
+        
+        // Mettre a jour l'outil PencilKit
+        canvasView?.tool = currentPKTool
+        
+        print("[DrawingCoordinator] PencilKit activated: \(tool), color: \(color), size: \(size)")
+    }
+    
+    func deactivatePencilKit() {
+        isPencilKitActive = false
+        canvasView?.drawing = PKDrawing() // Effacer le canvas
+        print("[DrawingCoordinator] PencilKit deactivated")
+    }
+    
+    func updatePageRect(_ rect: CGRect) {
+        self.pageRect = rect
+    }
+    
+    // MARK: - Communication avec le Web
+    
+    func sendStrokeToWeb(strokeData: StrokeData) {
+        guard let json = StrokeConverter.toJSON(strokeData) else {
+            print("[DrawingCoordinator] Failed to encode stroke")
+            return
+        }
+        
+        let js = "window.pencilKitBridge.onStrokeCompleted(\(json))"
+        
+        DispatchQueue.main.async { [weak self] in
+            self?.webView?.evaluateJavaScript(js) { result, error in
+                if let error = error {
+                    print("[DrawingCoordinator] JS error: \(error.localizedDescription)")
+                } else {
+                    print("[DrawingCoordinator] Stroke sent to web successfully")
+                }
+            }
+        }
+    }
+}
+
+// MARK: - UIColor hex extension
+
+extension UIColor {
+    convenience init?(hex: String) {
+        var hexSanitized = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        hexSanitized = hexSanitized.replacingOccurrences(of: "#", with: "")
+        
+        var rgb: UInt64 = 0
+        guard Scanner(string: hexSanitized).scanHexInt64(&rgb) else { return nil }
+        
+        let r = CGFloat((rgb & 0xFF0000) >> 16) / 255.0
+        let g = CGFloat((rgb & 0x00FF00) >> 8) / 255.0
+        let b = CGFloat(rgb & 0x0000FF) / 255.0
+        
+        self.init(red: r, green: g, blue: b, alpha: 1.0)
+    }
+}

--- a/profcalendar-app/ios/ProfCalendarViewer/Sources/Drawing/PencilKitOverlay.swift
+++ b/profcalendar-app/ios/ProfCalendarViewer/Sources/Drawing/PencilKitOverlay.swift
@@ -1,0 +1,72 @@
+//
+//  PencilKitOverlay.swift
+//  ProfCalendarViewer
+//
+//  Canvas PencilKit transparent qui se superpose a la WebView.
+//  Gere le dessin natif Apple Pencil avec zero latence.
+//
+
+import SwiftUI
+import PencilKit
+
+struct PencilKitOverlay: UIViewRepresentable {
+    @ObservedObject var coordinator: DrawingCoordinator
+    
+    func makeUIView(context: Context) -> PKCanvasView {
+        let canvas = PKCanvasView()
+        canvas.backgroundColor = .clear
+        canvas.isOpaque = false
+        canvas.drawingPolicy = .pencilOnly  // Seul l'Apple Pencil dessine
+        canvas.delegate = context.coordinator
+        canvas.tool = coordinator.currentPKTool
+        
+        // Desactiver le scroll du canvas
+        canvas.scrollView.isScrollEnabled = false
+        canvas.scrollView.bounces = false
+        
+        coordinator.canvasView = canvas
+        
+        return canvas
+    }
+    
+    func updateUIView(_ uiView: PKCanvasView, context: Context) {
+        uiView.tool = coordinator.currentPKTool
+    }
+    
+    func makeCoordinator() -> PencilKitDelegate {
+        PencilKitDelegate(drawingCoordinator: coordinator)
+    }
+}
+
+class PencilKitDelegate: NSObject, PKCanvasViewDelegate {
+    let drawingCoordinator: DrawingCoordinator
+    
+    init(drawingCoordinator: DrawingCoordinator) {
+        self.drawingCoordinator = drawingCoordinator
+    }
+    
+    func canvasViewDrawingDidChange(_ canvasView: PKCanvasView) {
+        // Un nouveau trait a ete complete
+        let drawing = canvasView.drawing
+        guard let lastStroke = drawing.strokes.last else { return }
+        
+        // Convertir le PKStroke en donnees JSON
+        let strokeData = StrokeConverter.convert(
+            stroke: lastStroke,
+            tool: drawingCoordinator.currentToolName,
+            color: drawingCoordinator.currentColorHex,
+            size: drawingCoordinator.currentSize,
+            opacity: drawingCoordinator.currentOpacity,
+            pageId: drawingCoordinator.currentPageId,
+            scale: drawingCoordinator.currentScale
+        )
+        
+        // Envoyer au web via JavaScript bridge
+        drawingCoordinator.sendStrokeToWeb(strokeData: strokeData)
+        
+        // Effacer le canvas PencilKit (le web prend le relais pour l'affichage)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            canvasView.drawing = PKDrawing()
+        }
+    }
+}

--- a/profcalendar-app/ios/ProfCalendarViewer/Sources/Drawing/StrokeConverter.swift
+++ b/profcalendar-app/ios/ProfCalendarViewer/Sources/Drawing/StrokeConverter.swift
@@ -1,0 +1,81 @@
+//
+//  StrokeConverter.swift
+//  ProfCalendarViewer
+//
+//  Convertit un PKStroke (PencilKit) en donnees JSON
+//  compatibles avec le format d'annotation de CleanPDFViewer.
+//
+
+import PencilKit
+import UIKit
+
+struct StrokePoint: Codable {
+    let x: Double
+    let y: Double
+    let pressure: Double
+}
+
+struct StrokeData: Codable {
+    let points: [StrokePoint]
+    let tool: String
+    let color: String
+    let size: Double
+    let opacity: Double
+    let pageId: String
+}
+
+class StrokeConverter {
+    
+    /// Convertit un PKStroke en StrokeData pour le bridge JavaScript
+    static func convert(
+        stroke: PKStroke,
+        tool: String,
+        color: String,
+        size: Double,
+        opacity: Double,
+        pageId: String,
+        scale: Double
+    ) -> StrokeData {
+        
+        var points: [StrokePoint] = []
+        let path = stroke.path
+        
+        // Echantillonner les points du stroke
+        // PKStrokePath est parametrique, on echantillonne a intervalles reguliers
+        let pointCount = max(Int(path.count), 2)
+        
+        for i in 0..<pointCount {
+            let point = path[i]
+            
+            // Convertir les coordonnees PencilKit -> coordonnees web
+            // Diviser par le scale pour obtenir les coordonnees non-zoomees
+            let webX = Double(point.location.x) / scale
+            let webY = Double(point.location.y) / scale
+            
+            // La force PencilKit (0-1) mappe directement sur la pression
+            let pressure = Double(point.force)
+            
+            points.append(StrokePoint(
+                x: webX,
+                y: webY,
+                pressure: min(max(pressure, 0.0), 1.0)
+            ))
+        }
+        
+        return StrokeData(
+            points: points,
+            tool: tool,
+            color: color,
+            size: size,
+            opacity: opacity,
+            pageId: pageId
+        )
+    }
+    
+    /// Encode un StrokeData en JSON string pour le bridge JavaScript
+    static func toJSON(_ strokeData: StrokeData) -> String? {
+        let encoder = JSONEncoder()
+        guard let data = try? encoder.encode(strokeData) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+}

--- a/profcalendar-app/ios/ProfCalendarViewer/Sources/WebView/PencilKitMessageHandler.swift
+++ b/profcalendar-app/ios/ProfCalendarViewer/Sources/WebView/PencilKitMessageHandler.swift
@@ -1,0 +1,88 @@
+//
+//  PencilKitMessageHandler.swift
+//  ProfCalendarViewer
+//
+//  Gere les messages JavaScript -> Swift pour PencilKit.
+//
+
+import WebKit
+
+class PencilKitMessageHandler: NSObject, WKScriptMessageHandler {
+    weak var coordinator: DrawingCoordinator?
+    
+    init(coordinator: DrawingCoordinator) {
+        self.coordinator = coordinator
+    }
+    
+    func userContentController(
+        _ userContentController: WKUserContentController,
+        didReceive message: WKScriptMessage
+    ) {
+        guard let body = message.body as? [String: Any],
+              let action = body["action"] as? String else {
+            print("[PencilKit] Invalid message format")
+            return
+        }
+        
+        let config = body["config"] as? [String: Any]
+        
+        DispatchQueue.main.async { [weak self] in
+            switch action {
+            case "activate":
+                self?.handleActivate(config: config)
+            case "deactivate":
+                self?.coordinator?.deactivatePencilKit()
+            case "updatePageRect":
+                self?.handleUpdatePageRect(config: config)
+            default:
+                print("[PencilKit] Unknown action: \(action)")
+            }
+        }
+    }
+    
+    private func handleActivate(config: [String: Any]?) {
+        guard let config = config else { return }
+        
+        let tool = config["tool"] as? String ?? "pen"
+        let color = config["color"] as? String ?? "#000000"
+        let size = config["size"] as? Double ?? 2.0
+        let opacity = config["opacity"] as? Double ?? 1.0
+        let scale = config["scale"] as? Double ?? 1.0
+        let pageId = config["pageId"] as? String ?? "page-1"
+        
+        // Page rect
+        var pageRect = CGRect.zero
+        if let rectData = config["pageRect"] as? [String: Any] {
+            pageRect = CGRect(
+                x: rectData["x"] as? Double ?? 0,
+                y: rectData["y"] as? Double ?? 0,
+                width: rectData["width"] as? Double ?? 0,
+                height: rectData["height"] as? Double ?? 0
+            )
+        }
+        
+        coordinator?.activatePencilKit(
+            tool: tool,
+            color: color,
+            size: size,
+            opacity: opacity,
+            pageRect: pageRect,
+            scale: scale,
+            pageId: pageId
+        )
+    }
+    
+    private func handleUpdatePageRect(config: [String: Any]?) {
+        guard let config = config,
+              let rectData = config["pageRect"] as? [String: Any] else { return }
+        
+        let rect = CGRect(
+            x: rectData["x"] as? Double ?? 0,
+            y: rectData["y"] as? Double ?? 0,
+            width: rectData["width"] as? Double ?? 0,
+            height: rectData["height"] as? Double ?? 0
+        )
+        
+        coordinator?.updatePageRect(rect)
+    }
+}

--- a/profcalendar-app/ios/ProfCalendarViewer/Sources/WebView/WebViewCoordinator.swift
+++ b/profcalendar-app/ios/ProfCalendarViewer/Sources/WebView/WebViewCoordinator.swift
@@ -1,0 +1,48 @@
+//
+//  WebViewCoordinator.swift
+//  ProfCalendarViewer
+//
+//  WKWebView qui charge profcalendar.org et gere le bridge JavaScript.
+//
+
+import SwiftUI
+import WebKit
+
+struct WebViewContainer: UIViewRepresentable {
+    @ObservedObject var coordinator: DrawingCoordinator
+    
+    func makeUIView(context: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        config.allowsInlineMediaPlayback = true
+        
+        // Enregistrer le handler pour les messages PencilKit
+        let handler = PencilKitMessageHandler(coordinator: coordinator)
+        config.userContentController.add(handler, name: "pencilKit")
+        
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.navigationDelegate = context.coordinator
+        webView.scrollView.bounces = false
+        
+        // Stocker la reference dans le coordinator
+        self.coordinator.webView = webView
+        
+        // Charger profcalendar
+        if let url = URL(string: "https://profcalendar-clean-dev.onrender.com") {
+            webView.load(URLRequest(url: url))
+        }
+        
+        return webView
+    }
+    
+    func updateUIView(_ uiView: WKWebView, context: Context) {}
+    
+    func makeCoordinator() -> WebViewNavigationDelegate {
+        WebViewNavigationDelegate()
+    }
+}
+
+class WebViewNavigationDelegate: NSObject, WKNavigationDelegate {
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        print("[WebView] Page loaded")
+    }
+}

--- a/static/js/clean-pdf-viewer.js
+++ b/static/js/clean-pdf-viewer.js
@@ -70,6 +70,10 @@ class CleanPDFViewer {
         this.penSmoothing = 0.5;
         this.penStreamline = 0;
         this.penSimulatePressure = false;
+        
+        // PencilKit bridge (WKWebView iOS natif)
+        this.pencilKitActive = false;
+        this.isPencilKitAvailable = !!(window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.pencilKit);
 
         // État du dessin
         this.isDrawing = false;
@@ -8791,6 +8795,153 @@ class CleanPDFViewer {
     }
 
 
+    // ==========================================
+    // PencilKit Bridge API (WKWebView iOS natif)
+    // ==========================================
+    
+    initPencilKitBridge() {
+        if (!this.isPencilKitAvailable) {
+            console.log('[PencilKit] Not in WKWebView, bridge disabled');
+            return;
+        }
+        
+        console.log('[PencilKit] Bridge initialized');
+        const viewer = this;
+        
+        // API globale que Swift appelle
+        window.pencilKitBridge = {
+            // Appele par Swift quand un trait est termine
+            onStrokeCompleted: (strokeData) => {
+                console.log('[PencilKit] Stroke received:', strokeData.points?.length, 'points');
+                const annotation = viewer.convertPencilKitStroke(strokeData);
+                if (annotation) {
+                    // Sauvegarder comme annotation standard
+                    const pageId = annotation.pageId;
+                    if (!viewer.annotations.has(pageId)) {
+                        viewer.annotations.set(pageId, []);
+                    }
+                    viewer.annotations.get(pageId).push(annotation);
+                    
+                    // Redessiner
+                    const canvas = document.querySelector('.annotation-canvas[data-page-id="' + pageId + '"]');
+                    if (canvas) {
+                        viewer.redrawAnnotations(canvas, pageId);
+                    }
+                    
+                    // Sauvegarder en base
+                    viewer.saveAnnotations();
+                    console.log('[PencilKit] Stroke saved as annotation');
+                }
+            },
+            
+            // Appele par Swift pour obtenir les infos de la page visible
+            getPageInfo: () => {
+                return {
+                    currentPage: viewer.currentPage,
+                    scale: viewer.currentScale,
+                    tool: viewer.currentTool,
+                    color: viewer.currentColor,
+                    size: viewer.currentSize,
+                    opacity: viewer.currentOpacity
+                };
+            },
+            
+            // Appele par Swift quand l'orientation change
+            onOrientationChanged: () => {
+                viewer.notifyPencilKitPageRect();
+            }
+        };
+    }
+    
+    // Convertir un stroke PencilKit en annotation standard
+    convertPencilKitStroke(strokeData) {
+        if (!strokeData || !strokeData.points || strokeData.points.length === 0) {
+            return null;
+        }
+        
+        return {
+            id: 'pk-' + Date.now() + '-' + Math.random().toString(36).substr(2, 9),
+            tool: strokeData.tool || 'pen',
+            color: strokeData.color || this.currentColor,
+            size: strokeData.size || this.currentSize,
+            opacity: strokeData.opacity || (strokeData.tool === 'highlighter' ? 0.5 : this.currentOpacity),
+            thinning: strokeData.thinning || this.penThinning,
+            smoothing: strokeData.smoothing || this.penSmoothing,
+            streamline: strokeData.streamline || this.penStreamline,
+            simulatePressure: false, // PencilKit fournit la vraie pression
+            points: strokeData.points.map(p => ({
+                x: p.x,
+                y: p.y,
+                pressure: p.pressure || 0.5
+            })),
+            source: 'pencilkit',
+            pageId: strokeData.pageId || this.getCurrentPageId(),
+            timestamp: Date.now()
+        };
+    }
+    
+    // Envoyer les coordonnees de la zone PDF visible a Swift
+    notifyPencilKitPageRect() {
+        if (!this.isPencilKitAvailable || !this.pencilKitActive) return;
+        
+        const pageContainer = document.querySelector('.pdf-page-container.active, .pdf-page-container');
+        if (!pageContainer) return;
+        
+        const rect = pageContainer.getBoundingClientRect();
+        window.webkit.messageHandlers.pencilKit.postMessage({
+            action: 'updatePageRect',
+            config: {
+                pageRect: { x: rect.left, y: rect.top, width: rect.width, height: rect.height },
+                scale: this.currentScale,
+                pageId: this.getCurrentPageId()
+            }
+        });
+    }
+    
+    // Activer PencilKit pour le dessin natif
+    activatePencilKit() {
+        if (!this.isPencilKitAvailable) return;
+        
+        this.pencilKitActive = true;
+        window.webkit.messageHandlers.pencilKit.postMessage({
+            action: 'activate',
+            config: {
+                tool: this.currentTool,
+                color: this.currentColor,
+                size: this.currentSize,
+                opacity: this.currentTool === 'highlighter' ? 0.5 : this.currentOpacity,
+                pageRect: this.getVisiblePageRect(),
+                scale: this.currentScale,
+                pageId: this.getCurrentPageId()
+            }
+        });
+        console.log('[PencilKit] Activated for tool:', this.currentTool);
+    }
+    
+    // Desactiver PencilKit
+    deactivatePencilKit() {
+        if (!this.isPencilKitAvailable) return;
+        
+        this.pencilKitActive = false;
+        window.webkit.messageHandlers.pencilKit.postMessage({
+            action: 'deactivate'
+        });
+        console.log('[PencilKit] Deactivated');
+    }
+    
+    // Obtenir le rectangle de la page visible
+    getVisiblePageRect() {
+        const pageContainer = document.querySelector('.pdf-page-container.active, .pdf-page-container');
+        if (!pageContainer) return { x: 0, y: 0, width: 0, height: 0 };
+        const rect = pageContainer.getBoundingClientRect();
+        return { x: rect.left, y: rect.top, width: rect.width, height: rect.height };
+    }
+    
+    // Obtenir l'ID de la page courante
+    getCurrentPageId() {
+        return 'page-' + (this.currentPage || 1);
+    }
+
     initPenSettingsPanel() {
         const toggleBtn = this.container.querySelector('#btn-pen-settings');
         const panel = this.container.querySelector('#pen-settings-panel');
@@ -8854,6 +9005,15 @@ class CleanPDFViewer {
     }
 
     setTool(tool) {
+        // PencilKit: activer/desactiver selon l'outil
+        if (this.isPencilKitAvailable) {
+            if (tool === 'pen' || tool === 'highlighter') {
+                this.activatePencilKit();
+            } else if (this.pencilKitActive) {
+                this.deactivatePencilKit();
+            }
+        }
+        
         console.log('[Tool] setTool appelé avec:', tool);
 
         // Désélectionner la zone de texte si on change d'outil (sauf si on reste sur text)


### PR DESCRIPTION
Adds native iOS app with PencilKit integration for zero-latency Apple Pencil drawing on iPad.

## Changes
- 7 Swift source files for the ProfCalendar iOS app
- - PencilKit overlay with pencilOnly drawing policy
- - WKWebView bridge for JS-Swift communication
- - Stroke conversion (PKStroke to JSON) with pressure data
- - Persistent cookie store for session management
## Note
These are iOS app source files only - no changes to the Flask web application.